### PR TITLE
Makes 'results button' and 'notebookoutput button' always visible

### DIFF
--- a/src/components/Content/ProjectContent/Experiment/Drawer/NotebookOutputs/_/index.js
+++ b/src/components/Content/ProjectContent/Experiment/Drawer/NotebookOutputs/_/index.js
@@ -5,6 +5,12 @@ import PropTypes from 'prop-types';
 // UI LIBS
 import { Button } from 'antd';
 
+// ANTD ICON
+import { CodeOutlined } from '@ant-design/icons';
+
+// button shape
+const icon = <CodeOutlined />;
+
 /**
  * Notebook Outputs.
  * This component is responsible for displaying a button that opens Jupyter.
@@ -17,8 +23,13 @@ const NotebookOutputs = (props) => {
 
   // rendering component
   return (
-    <Button onClick={handleOpenNotebookClick} shape='round' type='primary'>
-      Abrir notebook no Jupyter
+    <Button
+      onClick={handleOpenNotebookClick}
+      icon={icon}
+      shape='round'
+      type='primary-inverse'
+    >
+      Ver código no Jupyter
     </Button>
   );
 };

--- a/src/components/Content/ProjectContent/Experiment/Drawer/ResultsButtonBar/index.js
+++ b/src/components/Content/ProjectContent/Experiment/Drawer/ResultsButtonBar/index.js
@@ -5,6 +5,12 @@ import PropTypes from 'prop-types';
 // UI LIBS
 import { Button } from 'antd';
 
+// ANTD ICON
+import { TableOutlined } from '@ant-design/icons';
+
+// button shape
+const icon = <TableOutlined />;
+
 /**
  * Results Button Bar.
  * This component is responsible for displaying drawer results button bar.
@@ -35,11 +41,13 @@ const ResultsButtonBar = (props) => {
         shape='round'
         type='primary'
         disabled={disabled}
+        icon={icon}
         title={
           disabled
             ? 'Para visualizar os resultados, primeiro execute o treinamento.'
             : ''
         }
+        style={{ marginBottom: '14px' }}
       >
         Visualizar resultados
       </Button>

--- a/src/components/InputBlockContainer/InputBlockContainer.less
+++ b/src/components/InputBlockContainer/InputBlockContainer.less
@@ -1,7 +1,7 @@
 // input block
 .inputBlock {
   width: 100%;
-  padding: 20px;
+  padding: 16px;
 
   // when input block not is last child, render a bottom border
   &:not(:last-child) {

--- a/src/components/OperatorResizableSection/OperatorResizableSection.jsx
+++ b/src/components/OperatorResizableSection/OperatorResizableSection.jsx
@@ -80,12 +80,20 @@ const OperatorResizableSection = (props) => {
     <>
       {/* rendering data set drawer */}
       {operatorIsDataset && <DatasetDrawerContainer />}
-      {/* rendering generic drawer */}
-      {!operatorIsDataset && <GenericDrawerContainer />}
 
-      {/* rendering results button bar */}
-      {!operatorIsDataset && (
-        <InputBlockContainer>
+      <div
+        style={{
+          overflowY: 'auto',
+          borderBottom: '1px solid rgba(0, 0, 0, 0.09)',
+        }}
+      >
+        {/* rendering generic drawer */}
+        {!operatorIsDataset && <GenericDrawerContainer />}
+      </div>
+
+      <InputBlockContainer>
+        {/* rendering results button bar */}
+        {!operatorIsDataset && (
           <ResultsButtonBar
             handleEditClick={() => undefined}
             handleResultsClick={handleShowResultsClick}
@@ -98,15 +106,11 @@ const OperatorResizableSection = (props) => {
                 operatorResults.lenght <= 0)
             }
           />
-        </InputBlockContainer>
-      )}
+        )}
 
-      {/* rendering link to Jupyter */}
-      {!operatorIsDataset && (
-        <InputBlockContainer>
-          <NotebookOutputsContainer />
-        </InputBlockContainer>
-      )}
+        {/* rendering link to Jupyter */}
+        {!operatorIsDataset && <NotebookOutputsContainer />}
+      </InputBlockContainer>
     </>
   ) : undefined;
 

--- a/src/components/ResizableSection/ResizableSection.less
+++ b/src/components/ResizableSection/ResizableSection.less
@@ -41,14 +41,11 @@
 .resizable-section-body {
   color: #262626;
   background-color: #fafafa;
-  align-items: center;
-  display: inline-block;
-  width: 100%;
+  align-items: stretch;
+  display: flex;
   height: 100%;
-  margin-left: 1px;
-  padding: 0px;
-  overflow-y: auto;
-  overflow-x: hidden;
+  flex-direction: column;
+  justify-content: space-between;
   padding-bottom: 50px;
 }
 


### PR DESCRIPTION
Always shows these buttons since they are very important features.
The scroll bar now is only for parameters.

Also adds Icons to these buttons to match the layout.