### PR TITLE
Fixing the tilt bug on experiments tab

### DIFF
--- a/src/components/Content/ContentHeader/_/ContentHeaderProjectContainer.js
+++ b/src/components/Content/ContentHeader/_/ContentHeaderProjectContainer.js
@@ -41,7 +41,7 @@ const mapStateToProps = (state) => {
  */
 const ContentHeaderProjectContainer = (props) => {
   // destructuring props
-  const { project, loading, handleFetchProject, handleEditProjectName } = props;
+  const { project, handleFetchProject, handleEditProjectName } = props;
 
   // CONSTANTS
   // getting history
@@ -70,7 +70,6 @@ const ContentHeaderProjectContainer = (props) => {
       subTitle='Meus projetos'
       handleGoBack={goBackHandler}
       handleSubmit={editProjectNameHandler}
-      loading={loading}
       extra={
         <>
           <ExperimentButtonsContainer />

--- a/src/components/Content/ProjectContent/ExperimentsTabs/_/Container.js
+++ b/src/components/Content/ProjectContent/ExperimentsTabs/_/Container.js
@@ -90,12 +90,15 @@ const ExperimentTabsContainer = (props) => {
   useEffect(() => {
     // fetching projects
     handleFetchExperiments(projectId);
+  }, [handleFetchExperiments, projectId, handleClearAllExperiments]);
 
+  useEffect(() => {
     return () => {
       // clear all experiments of redux when dismount
       handleClearAllExperiments();
     };
-  }, [handleFetchExperiments, projectId, handleClearAllExperiments]);
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // listen experiments to redirect to active
   useEffect(() => {

--- a/src/components/Content/ProjectContent/ExperimentsTabs/_/Container.js
+++ b/src/components/Content/ProjectContent/ExperimentsTabs/_/Container.js
@@ -53,7 +53,6 @@ const mapDispatchToProps = (dispatch, routerProps) => {
 const mapStateToProps = (state) => {
   return {
     experiments: state.experimentsReducer,
-    loading: state.uiReducer.experimentsTabs.loading,
   };
 };
 

--- a/src/components/Content/ProjectContent/ExperimentsTabs/_/index.js
+++ b/src/components/Content/ProjectContent/ExperimentsTabs/_/index.js
@@ -10,7 +10,7 @@ import {
   EditOutlined,
   LoadingOutlined,
 } from '@ant-design/icons';
-import { Tabs, Spin, Popconfirm, Popover, Input } from 'antd';
+import { Tabs, Popconfirm, Popover, Input } from 'antd';
 
 // COMPONENTS
 import DraggableTabs from '../DraggableTabs';
@@ -131,12 +131,8 @@ const ExperimentsTabs = (props) => {
       // rendering loading tab
       return (
         <TabPane
-          tab={
-            <div className='tab-title-custom'>
-              <Spin size='small' indicator={<LoadingOutlined />} />
-            </div>
-          }
-          disabled
+          tab={<div className='tab-title-custom' />}
+          disabled={loading}
           key='sem experimento'
         />
       );


### PR DESCRIPTION
Removed the load on the experiment tab and the title of the projects so that there are no "tilts" on screen