### PR TITLE
Feature/image inference

### DIFF
--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/UploadInferenceTestButton/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/UploadInferenceTestButton/index.js
@@ -15,7 +15,7 @@ const UploadInferenceTestButton = ({ handleUpload }) => {
   const props = {
     name: 'file',
     showUploadList: false,
-    accept: '.csv',
+    accept: ['.csv', '.jpg', '.jpeg', '.png'],
   };
 
   // RENDER
@@ -24,20 +24,36 @@ const UploadInferenceTestButton = ({ handleUpload }) => {
     <Upload
       beforeUpload={(file) => {
         const reader = new FileReader();
+        const acceptedImagesTypes = ['image/jpg', 'image/jpeg', 'image/png'];
+        const isImage = acceptedImagesTypes.includes(file.type);
 
         reader.onload = (e) => {
-          // need to remove the windows end of line
-          const result = e.target.result.trim().replace(/\r/g, '').split('\n');
-          const [names, ...ndarray] = result;
-          const obj = {
-            data: {
-              names: names.split(','),
-              ndarray: ndarray.map((el) => el.split(',')),
-            },
-          };
+          let obj;
+
+          if (isImage) {
+            obj = {
+              data: {
+                ndarray: [[e.target.result]],
+              },
+            };
+          } else {
+            // need to remove the windows end of line
+            const result = e.target.result
+              .trim()
+              .replace(/\r/g, '')
+              .split('\n');
+            const [names, ...ndarray] = result;
+            obj = {
+              data: {
+                names: names.split(','),
+                ndarray: ndarray.map((el) => el.split(',')),
+              },
+            };
+          }
           handleUpload(obj);
         };
-        reader.readAsText(file);
+
+        isImage ? reader.readAsDataURL(file) : reader.readAsText(file);
         return false;
       }}
       {...props}

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
@@ -197,9 +197,8 @@ const ImplantedExperimentsTable = (props) => {
               dataIndex: name,
               key: name,
               width: 100,
-              // colSpan: 50,
             }))}
-            // scroll={{ x: 800 }}
+            scroll={{ x: 800 }}
           />
         )}
       </Modal>

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
@@ -53,6 +53,27 @@ const ImplantedExperimentsTable = (props) => {
     Succeeded: 'success',
   };
 
+  // check if a ndarray is base64 and image/jpg
+  const isBase64Encoded = (ndarray) => {
+    const pattern = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+    const baseValue = ndarray.find((value) => typeof value === 'string');
+
+    if (baseValue) {
+      const [base, content] = baseValue.split(',');
+
+      if (base.includes('image/jpeg') && pattern.test(content)) return true;
+      else return false;
+    } else {
+      return false;
+    }
+  };
+
+  console.log(
+    experimentInference.names.map((name) => {
+      return { title: name, dataIndex: name, key: name };
+    })
+  );
+
   // table columns config
   const columnsConfig = [
     // status column
@@ -150,23 +171,37 @@ const ImplantedExperimentsTable = (props) => {
         visible={experimentInferenceModal}
         onOk={closeModal}
         onCancel={closeModal}
+        width='70vw'
       >
-        <Table
-          dataSource={experimentInference.ndarray.map((e, i) => {
-            const data = { key: i };
-            experimentInference.names.forEach((c, j) => {
-              data[c] = e[j];
-            });
-            return data;
-          })}
-          columns={experimentInference.names.map((name) => ({
-            title: name,
-            dataIndex: name,
-            key: name,
-          }))}
-          scroll={{ x: 800 }}
-        />
-        ;
+        {isBase64Encoded(experimentInference.ndarray) ? (
+          <div className='container-difference'>
+            <img
+              src={experimentInference.ndarray.map((element) => {
+                return element;
+              })}
+              alt='predict-response'
+              className='image-difference'
+            />
+          </div>
+        ) : (
+          <Table
+            dataSource={experimentInference.ndarray.map((e, i) => {
+              const data = { key: i };
+              experimentInference.names.forEach((c, j) => {
+                data[c] = e[j];
+              });
+              return data;
+            })}
+            columns={experimentInference.names.map((name) => ({
+              title: name,
+              dataIndex: name,
+              key: name,
+              width: 100,
+              // colSpan: 50,
+            }))}
+            // scroll={{ x: 800 }}
+          />
+        )}
       </Modal>
     </>
   );

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
@@ -198,7 +198,7 @@ const ImplantedExperimentsTable = (props) => {
               />
             ) : (
               <div className='iterative-prediction'>
-                <Tooltip title='O formato gerado pelo modelo não é do tipo imagem. Veja mais sobre essa saída logo abaixo!'>
+                <Tooltip title='O formato do arquivo gerado pelo modelo não é do tipo imagem. Veja mais sobre essa saída logo abaixo!'>
                   <span>Arquivo gerado pelo modelo</span>
                 </Tooltip>
                 <div className='show-code'>

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
@@ -62,7 +62,6 @@ const ImplantedExperimentsTable = (props) => {
       const [base, content] = baseValue.split(',');
 
       if (base.includes('image/jpeg') && pattern.test(content)) return true;
-      else return false;
     } else {
       return false;
     }

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/style.less
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/style.less
@@ -28,3 +28,11 @@
   display: flex;
   justify-content: center;
 }
+
+.show-code {
+  overflow-y: scroll;
+  padding: 0px;
+  border: 2px solid#E8E8E8;
+  height: 200px;
+  width: 500px;
+}

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/style.less
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/style.less
@@ -18,3 +18,13 @@
                                 supported by Chrome and Opera */
   }
 }
+
+.image-difference {
+  max-width: 100%;
+  height: auto;
+}
+
+.container-difference {
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
Test Inference for Images
- add support for inference of jpg, jpeg and png extension files
- display image instead of the csv table whenever the response is coded in base64 and type image/jpeg
