### PR TITLE
Text and styles adjustments

### DIFF
--- a/src/components/Content/ImplantedExperimentsContent/ButtonUsingDeployments/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ButtonUsingDeployments/index.js
@@ -16,7 +16,7 @@ const ButtonUsingDeployments = ({ handleClick }) => (
     onClick={handleClick}
     icon={<QuestionCircleOutlined />}
     className='newProjectButton'
-    type='secondary'
+    type='primary'
   >
     Como usar um fluxo implantado?
   </Button>

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/UploadInferenceTestButton/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/UploadInferenceTestButton/index.js
@@ -61,7 +61,7 @@ const UploadInferenceTestButton = ({ handleUpload }) => {
       {/* upload button link */}
       <Button type='link'>
         <UploadOutlined style={{ marginRight: 5 }} />
-        Testar Inferência
+        Testar o fluxo
       </Button>
     </Upload>
   );

--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/_/index.js
@@ -93,7 +93,7 @@ const ImplantedExperimentsTable = (props) => {
   const columnsConfig = [
     // status column
     {
-      title: 'Status',
+      title: <strong>Status</strong>,
       dataIndex: 'status',
       key: 'status',
       render: (value) => (
@@ -103,13 +103,13 @@ const ImplantedExperimentsTable = (props) => {
     },
     // name
     {
-      title: 'Nome',
+      title: <strong>Nome</strong>,
       dataIndex: 'name',
       key: 'name',
     },
     // url column
     {
-      title: 'URL',
+      title: <strong>URL</strong>,
       dataIndex: 'url',
       key: 'url',
       render: (value) => (
@@ -122,14 +122,14 @@ const ImplantedExperimentsTable = (props) => {
     },
     // createdAt column
     {
-      title: 'Data de Criação',
+      title: <strong>Data de Criação</strong>,
       dataIndex: 'createdAt',
       key: 'createdAt',
       render: (value) => new Date(value).toLocaleString(),
     },
     // action column
     {
-      title: 'Ação',
+      title: <strong>Ação</strong>,
       dataIndex: 'action',
       key: 'action',
       render: (value, record) => (
@@ -182,7 +182,7 @@ const ImplantedExperimentsTable = (props) => {
       />
       <LogsDrawer />
       <Modal
-        title='Predições'
+        title={<strong>Visualizar resultados</strong>}
         visible={experimentInferenceModal}
         onOk={closeModal}
         onCancel={closeModal}

--- a/src/components/Content/ImplantedExperimentsContent/LogsDrawer/Container.js
+++ b/src/components/Content/ImplantedExperimentsContent/LogsDrawer/Container.js
@@ -46,7 +46,7 @@ const DrawerContainer = ({
       handleClose={handleHideDrawer}
       results={results}
       resultsLoading={resultsLoading}
-      title={drawer.title}
+      title={<strong>{drawer.title}</strong>}
       logs={logs}
     />
   );

--- a/src/components/Content/ImplantedExperimentsContent/LogsDrawer/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/LogsDrawer/index.js
@@ -16,6 +16,8 @@ const Drawer = ({ title, isVisible, logs, handleClose }) => {
   // EMPTY COMPONENT
   const renderEmpty = () => <span>Não há dados.</span>;
 
+  const containersCount = logs.length;
+
   // COLUMNS OF LOG TABLE
   const logsTableColumns = [
     {
@@ -63,7 +65,13 @@ const Drawer = ({ title, isVisible, logs, handleClose }) => {
       onClose={handleClose}
       destroyOnClose
     >
-      <span>Container</span>
+      {/* data header */}
+      <div>
+        <span style={{ fontSize: '12px' }}>CONTAINERS EM EXECUÇÃO: </span>
+        <span style={{ color: '#262626', fontSize: '14px' }}>
+          {containersCount}
+        </span>
+      </div>
       <Tabs>
         {logs.map((container, i) => (
           <TabPane tab={container.containerName} key={i}>

--- a/src/components/Content/ImplantedExperimentsContent/UsingDeploymentsModal/Container.js
+++ b/src/components/Content/ImplantedExperimentsContent/UsingDeploymentsModal/Container.js
@@ -106,7 +106,7 @@ const NewDeploymentsModalContainer = ({ visible, handleCloseModal }) => (
   <DeploymentsModal
     visible={visible}
     handleCloseModal={handleCloseModal}
-    title='Como usar um fluxo implantado?'
+    title={<strong>Como usar um fluxo implantado?</strong>}
   >
     <ContentInfo />
   </DeploymentsModal>


### PR DESCRIPTION
- Replaces 'Testar inferência' by 'Testar o fluxo'
(not every deployment is a model inference).
- Wraps titles in a tag `<strong>`
- Show running container count in Logs drawer