### PR TITLE
Fix a bug when selecting a dataset from list

### DIFF
--- a/src/components/InputBlocks/UploadInputBlock/UploadInputBlock.jsx
+++ b/src/components/InputBlocks/UploadInputBlock/UploadInputBlock.jsx
@@ -61,7 +61,7 @@ const UploadInputBlock = (props) => {
     buttonText,
     datasets,
     datasetsLoading,
-    handleFetchDataset,
+    handleSelectDataset,
     handleUploadCancel,
     handleUploadFail,
     handleUploadStart,
@@ -126,7 +126,7 @@ const UploadInputBlock = (props) => {
     // stop opening the upload modal
     e.domEvent.stopPropagation();
 
-    handleFetchDataset(e.key);
+    handleSelectDataset(e.key);
   };
 
   const datasetsMenu = (
@@ -138,17 +138,17 @@ const UploadInputBlock = (props) => {
         overflow: 'auto',
       }}
     >
-      {
-        datasets.length > 0
-        ? datasets.map((dataset) => (
+      {datasets.length > 0 ? (
+        datasets.map((dataset) => (
           <Menu.Item key={dataset.name}>{dataset.name}</Menu.Item>
         ))
-        : <Empty
+      ) : (
+        <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description='Não há conjuntos de dados.'
-          style={{ paddingLeft: '10px', paddingRight: '10px' }} 
+          style={{ paddingLeft: '10px', paddingRight: '10px' }}
         />
-      }
+      )}
     </Menu>
   );
 
@@ -197,8 +197,8 @@ UploadInputBlock.propTypes = {
   /** Datasets list is loading */
   datasetsLoading: PropTypes.bool.isRequired,
 
-  /** Fetch dataset by name handler */
-  handleFetchDataset: PropTypes.func.isRequired,
+  /** Dataset selected handler */
+  handleSelectDataset: PropTypes.func.isRequired,
 
   /** Upload cancel handler */
   handleUploadCancel: PropTypes.func.isRequired,

--- a/src/containers/DatasetUploadInputBlockContainer/DatasetUploadInputBlockContainer.jsx
+++ b/src/containers/DatasetUploadInputBlockContainer/DatasetUploadInputBlockContainer.jsx
@@ -12,7 +12,7 @@ import {
 
 // ACTIONS
 import {
-  getDatasetRequest,
+  selectDataset,
   startDatasetUpload,
   cancelDatasetUpload,
   createGoogleDataset,
@@ -26,7 +26,8 @@ import { fetchDatasetsRequest } from 'store/datasets/actions';
 const mapDispatchToProps = (dispatch) => {
   return {
     // start dataset upload
-    handleFetchDataset: (e) => dispatch(getDatasetRequest(e)),
+    handleSelectDataset: (dataset, projectId, experimentId) =>
+      dispatch(selectDataset(dataset, projectId, experimentId)),
     handleFetchDatasets: () => dispatch(fetchDatasetsRequest()),
     handleCreateGoogleDataset: (projectId, experimentId, file) =>
       dispatch(createGoogleDataset(projectId, experimentId, file)),
@@ -60,7 +61,7 @@ const DatasetUploadInputBlockContainer = (props) => {
     datasetFileName,
     datasetStatus,
     handleCreateGoogleDataset,
-    handleFetchDataset,
+    handleSelectDataset,
     handleFetchDatasets,
     handleUploadCancel,
     handleDeleteDataset,
@@ -127,6 +128,9 @@ const DatasetUploadInputBlockContainer = (props) => {
       ? handleDeleteDataset(projectId, experimentId)
       : handleUploadCancel();
 
+  const containerHandleSelectDataset = (dataset) =>
+    handleSelectDataset(dataset, projectId, experimentId);
+
   // rendering component
   return isGoogleDrive ? (
     <GoogleUploadInputBlock
@@ -144,7 +148,7 @@ const DatasetUploadInputBlockContainer = (props) => {
       buttonText={buttonText}
       datasets={datasets}
       datasetsLoading={datasetsLoading}
-      handleFetchDataset={handleFetchDataset}
+      handleSelectDataset={containerHandleSelectDataset}
       handleUploadCancel={containerHandleUploadCancel}
       handleUploadFail={handleUploadFail}
       handleUploadStart={handleUploadStart}
@@ -165,8 +169,8 @@ DatasetUploadInputBlockContainer.propTypes = {
   /** Datasets list is loading */
   datasetsLoading: PropTypes.bool.isRequired,
 
-  /** Fetch dataset by name handler */
-  handleFetchDataset: PropTypes.func.isRequired,
+  /** Select dataset handler */
+  handleSelectDataset: PropTypes.func.isRequired,
 
   /** Fetch all datasets handler */
   handleFetchDatasets: PropTypes.func.isRequired,

--- a/src/store/dataset/actions.js
+++ b/src/store/dataset/actions.js
@@ -345,6 +345,28 @@ export const getDatasetRequest = (datasetName) => (dispatch) => {
 
 // // // // // // // // // //
 
+// ** SELECT DATASET
+/**
+ * select dataset action
+ *
+ * @param datasetName
+ * @returns {Function}
+ */
+export const selectDataset = (datasetName, projectId, experimentId) => (
+  dispatch
+) => {
+  // fetching dataset
+  datasetsApi
+    .getDataset(datasetName, 1, 10)
+    .then((response) => {
+      const dataset = response.data;
+      dispatch(datasetUploadSuccess(dataset, projectId, experimentId));
+    })
+    .catch((error) => dispatch(getDatasetFail(error)));
+};
+
+// // // // // // // // // //
+
 // ** DELETE DATASET
 
 /**


### PR DESCRIPTION
After select the dropdown items, only getDatasetRequest was dispatched.
However, all actions in 'datasetUploadSuccess' should also be performed:
- set operator parameters (dataset)
- clear feature parameters in other operators