### PR TITLE
Handle Experiment without DATASET

### DIFF
--- a/src/components/Content/ContentHeader/ExperimentButtons/Container.js
+++ b/src/components/Content/ContentHeader/ExperimentButtons/Container.js
@@ -49,14 +49,17 @@ const ExperimentButtonsContainer = ({
 }) => {
   // CONSTANTS
   const { experimentId } = useParams();
-  const { deployStatus, succeeded: trainingSucceeded } = experiment;
+  const { deployStatus } = experiment;
 
   // Checks if the experiment has, at least, one non DATASET operator
-  const hasExecutorOperator = operators
-    .map((operator) => {
-      return operator.tags.includes('DATASETS') && operator.tags.length > 0;
-    })
-    .every((value) => value === true);
+  const hasExecutorOperator = operators.some((operator) => {
+    return !operator.tags.includes('DATASETS') && operator.tags.length > 0;
+  });
+
+  // Check if any operator has failed
+  const hasFailed = operators.some((operator) => {
+    return operator.status === 'Failed';
+  });
 
   // HOOKS
   // did mount hook
@@ -77,10 +80,10 @@ const ExperimentButtonsContainer = ({
     <ExperimentButtons
       handleClick={deployExperimentHandler}
       disabled={
-        hasExecutorOperator ||
+        !hasExecutorOperator ||
         loading ||
         trainingLoading ||
-        !trainingSucceeded ||
+        hasFailed ||
         deployStatus === 'Succeeded' ||
         deployStatus === 'Running'
       }

--- a/src/components/Content/ContentHeader/ExperimentButtons/Container.js
+++ b/src/components/Content/ContentHeader/ExperimentButtons/Container.js
@@ -51,6 +51,13 @@ const ExperimentButtonsContainer = ({
   const { experimentId } = useParams();
   const { deployStatus, succeeded: trainingSucceeded } = experiment;
 
+  // Checks if the experiment has, at least, one non DATASET operator
+  const hasExecutorOperator = operators
+    .map((operator) => {
+      return operator.tags.includes('DATASETS') && operator.tags.length > 0;
+    })
+    .every((value) => value === true);
+
   // HOOKS
   // did mount hook
   useEffect(() => {
@@ -70,6 +77,7 @@ const ExperimentButtonsContainer = ({
     <ExperimentButtons
       handleClick={deployExperimentHandler}
       disabled={
+        hasExecutorOperator ||
         loading ||
         trainingLoading ||
         !trainingSucceeded ||

--- a/src/components/Content/ProjectContent/Experiment/ExperimentHeader/_/Container.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentHeader/_/Container.js
@@ -97,7 +97,7 @@ const ExperimentHeaderContainer = ({
   return (
     <ExperimentHeader
       title={experiment.name}
-      empty={operators.length < 2}
+      empty={operators.length <= 0}
       loading={loading}
       operator={operator}
       trainingLoading={trainingLoading}


### PR DESCRIPTION
- enable "Executar" button when there is at least one operator of any kind
- enable "Preparar para a implantação" button even when a flow has not been executed (and when there are at least one non DATASET operator)