### PR TITLE
Use replace instead replaceAll

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -582,7 +582,7 @@ const getFeaturetypes = (dataset) => {
       return column.featuretype;
     });
 
-    return featuretypes.toString().replaceAll(',', '\n');
+    return featuretypes.toString().replace(/,/g, '\n');
   }
   return false;
 };


### PR DESCRIPTION
- replaceAll() doesn't work on older browser versions, to fix we are using replace() instead.