### PR TITLE
Fix Deployment Logs Drawer

### DIFF
--- a/src/store/pipelines/actions.js
+++ b/src/store/pipelines/actions.js
@@ -223,7 +223,7 @@ export const getTrainExperimentStatusRequest = (experimentId) => (dispatch) => {
  * deploy experiment success action
  * @param {string} experimentId
  * @param {Object} routerProps
- * @returns {Function}
+ * @returns {Object} { type }
  */
 const deployExperimentSuccess = (experimentId, routerProps) => () => {
   // go to deployed experiments

--- a/src/store/pipelines/actions.js
+++ b/src/store/pipelines/actions.js
@@ -4,6 +4,8 @@ import actionTypes from './actionTypes';
 // EXPERIMENT ACTION TYPES
 import experimentActionTypes from '../experiment/actionTypes';
 
+import uiActionTypes from '../ui/actionTypes'
+
 // SERVICES
 import pipelinesApi from '../../services/PipelinesApi';
 
@@ -221,7 +223,7 @@ export const getTrainExperimentStatusRequest = (experimentId) => (dispatch) => {
  * deploy experiment success action
  * @param {string} experimentId
  * @param {Object} routerProps
- * @returns {Object} { type }
+ * @returns {Function}
  */
 const deployExperimentSuccess = (experimentId, routerProps) => () => {
   // go to deployed experiments
@@ -264,6 +266,11 @@ export const deployExperimentRequest = (
   // dispatching request action
   dispatch({
     type: actionTypes.DEPLOY_EXPERIMENT_REQUEST,
+  });
+
+  // dispatching hide drawer action
+  dispatch({
+    type: uiActionTypes.HIDE_DRAWER
   });
 
   // creating deploy object


### PR DESCRIPTION
- Bug: when deploying right after selecting a flow operator, a log drawer was displayed on the screen /fluxos-implantados since the drawer that displays the operator data is the same as that displays the deployment logs
- Solution: change the state of the log drawer when making PUT request in Pipelines