### PR TITLE
Fix Type Validation

### DIFF
--- a/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/UploadInferenceTestButton/index.js
+++ b/src/components/Content/ImplantedExperimentsContent/ImplantedExperimentsTable/UploadInferenceTestButton/index.js
@@ -30,16 +30,16 @@ const UploadInferenceTestButton = ({ handleUpload }) => {
         let [type, subtype] = file.type.split('/');
         const isImageOrVideo = ['image', 'video'].includes(type);
 
-        if (type === '' && subtype === '') {
+        if (type === '') {
           // Some browsers draws the MIME types from the operating system,
           // so if you OS knows the correct MIME type for .csv or .txt, the browser
           // would show it as well. Please, check the settings of your OS.
           const extensionPattern = /(?:\.([^.]+))?$/;
-          const ext = extensionPattern.exec(file.name);
+          const extension = extensionPattern.exec(file.name);
 
-          if (ext) {
+          if (extension) {
             type = 'text';
-            subtype = ext.shift();
+            subtype = extension.shift();
           }
         }
 
@@ -74,8 +74,6 @@ const UploadInferenceTestButton = ({ handleUpload }) => {
               binData: btoa(unescape(encodeURIComponent(e.target.result))),
             };
           }
-
-          console.log(obj);
           handleUpload(obj);
         };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -596,8 +596,8 @@ const getFeaturetypes = (dataset) => {
  * @returns {boolean} if a response includes a encoded base64 string or not
  */
 const isSupportedBinaryData = (response) => {
-  const isExpectedResponse = ['binData', 'strData'].includes(
-    Object.keys(response).shift()
+  const isExpectedResponse = Object.keys(response).some((key) =>
+    ['binData', 'strData'].includes(key)
   )
     ? true
     : false;


### PR DESCRIPTION
- verify only if `type` is a empty string
- make `isSupportedBinaryData` more generic when validate a object response