### PR TITLE
Fix Fast Swapping Between Experiments

### DIFF
--- a/src/components/Content/ProjectContent/ExperimentsTabs/_/Container.js
+++ b/src/components/Content/ProjectContent/ExperimentsTabs/_/Container.js
@@ -67,6 +67,8 @@ const mapDispatchToProps = (dispatch, routerProps) => {
 const mapStateToProps = (state) => {
   return {
     experiments: state.experimentsReducer,
+    experimentDetailsLoading: state.uiReducer.experimentsTabs.loading,
+    experimentOperatorsLoading: state.uiReducer.experimentOperators.loading,
   };
 };
 
@@ -83,7 +85,8 @@ const ExperimentTabsContainer = (props) => {
   // destructuring props
   const {
     experiments,
-    loading,
+    experimentDetailsLoading,
+    experimentOperatorsLoading,
     handleFetchExperiments,
     handleOrganizeExperiments,
     handleFetchExperiment,
@@ -174,7 +177,7 @@ const ExperimentTabsContainer = (props) => {
       experiments={experiments}
       handleChange={handleChangeTab}
       handleMoveTab={handleOrganizeTabs}
-      loading={loading}
+      loading={experimentDetailsLoading || experimentOperatorsLoading}
       deleteHandler={deleteHandler}
       renameHandler={renameHandler}
       duplicateHandler={duplicateHandler}

--- a/src/components/Content/ProjectContent/ExperimentsTabs/_/index.js
+++ b/src/components/Content/ProjectContent/ExperimentsTabs/_/index.js
@@ -75,7 +75,9 @@ const ExperimentsTabs = (props) => {
         >
           <div className='tab-title-custom'>
             {title}
-            {(running || loadingTitle) && <LoadingOutlined />}
+            {(running || loadingTitle) && activeExperiment === experimentId && (
+              <LoadingOutlined />
+            )}
           </div>
           {experimentId && (
             <Popconfirm

--- a/src/store/operators/actions.js
+++ b/src/store/operators/actions.js
@@ -13,6 +13,8 @@ import {
   experimentOperatorsLoadingData,
   operatorParameterLoadingData,
   operatorParameterDataLoaded,
+  experimentsTabsLoadingData,
+  experimentsTabsDataLoaded,
 } from '../ui/actions';
 
 // PIPELINES ACTIONS
@@ -37,6 +39,9 @@ const fetchOperatorsSuccess = (operators, experimentId) => (dispatch) => {
   // dispatching experiment operators data loaded action
   dispatch(experimentOperatorsDataLoaded());
 
+  // dispatching experiment tabs data loaded action
+  dispatch(experimentsTabsDataLoaded());
+
   // dispatching get training experiment status request action
   dispatch(getTrainExperimentStatusRequest(experimentId));
 
@@ -59,6 +64,9 @@ const fetchOperatorsFail = (error) => (dispatch) => {
 
   // dispatching experiment operators data loaded action
   dispatch(experimentOperatorsDataLoaded());
+
+    // dispatching experiment tabs data loaded action
+    dispatch(experimentsTabsDataLoaded());
 
   // dispatching fetch operators fail
   dispatch({
@@ -85,6 +93,9 @@ export const fetchOperatorsRequest = (projectId, experimentId) => async (
 
   // dispatching experiment operators loading data action
   dispatch(experimentOperatorsLoadingData());
+
+  // dispatching experiment tabs loading data action
+  dispatch(experimentsTabsLoadingData());
 
   try {
     // getting tasks


### PR DESCRIPTION
- Bug: when switching quickly between experiments, an exception was caused due to the number of requests made.
- Solution: make the `Tab` of experiments be disabled until the operator request and the experiment details request is completed