### PR TITLE
Fix docker build for web-ui:<VERSION>-AUTH

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -65,3 +65,4 @@ jobs:
           registry: registry.hub.docker.com
           repository: platiagro/web-ui
           tags: ${{ steps.var.outputs.TAG }}-AUTH
+          build_args: auth=true


### PR DESCRIPTION
Adds build-args auth=true to the right configuration is used.