### PR TITLE
Feature/use provider states flow

### DIFF
--- a/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/Container.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/Container.js
@@ -13,7 +13,6 @@ import {
   deselectOperator,
   saveOperatorPosition,
 } from '../../../../../../store/operator/actions';
-import { saveFlowTransform } from '../../../../../../store/ui/actions';
 import { useStoreState } from 'react-flow-renderer';
 
 // DISPATCHS
@@ -36,8 +35,6 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(
         saveOperatorPosition(projectId, experimentId, operatorId, position)
       ),
-    handleSaveFlowTransform: (transform) =>
-      dispatch(saveFlowTransform(transform)),
   };
 };
 
@@ -47,7 +44,6 @@ const mapStateToProps = (state) => {
     operators: state.operatorsReducer,
     datasetName: state.experimentReducer.dataset,
     loading: state.uiReducer.experimentOperators.loading,
-    flowTransform: state.uiReducer.flowTransform,
   };
 };
 
@@ -63,8 +59,6 @@ const pollingTime = 5000;
 const ExperimentFlowContainer = ({
   operators,
   loading,
-  flowTransform,
-  handleSaveFlowTransform,
   handleShowOperatorDetails,
   handleGetTrainExperimentStatus,
   handleDeselectOperator,
@@ -73,8 +67,8 @@ const ExperimentFlowContainer = ({
   // CONSTANTS
   // getting experiment uuid
   const { projectId, experimentId } = useParams();
-  const transformations = useStoreState((store) => store.transform);
-  console.log(transformations);
+
+  const transformations = useStoreState((flowStore) => flowStore.transform);
 
   // HOOKS
   // did mount hook
@@ -100,8 +94,6 @@ const ExperimentFlowContainer = ({
     <ExperimentFlow
       tasks={operators}
       loading={loading}
-      flowTransform={flowTransform}
-      handleSaveFlowTransform={handleSaveFlowTransform}
       handleTaskBoxClick={selectOperatorHandler}
       handleDeselectOperator={handleDeselectOperator}
       handleSavePosition={handleSavePosition}

--- a/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/Container.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/Container.js
@@ -14,6 +14,7 @@ import {
   saveOperatorPosition,
 } from '../../../../../../store/operator/actions';
 import { saveFlowTransform } from '../../../../../../store/ui/actions';
+import { useStoreState } from 'react-flow-renderer';
 
 // DISPATCHS
 const mapDispatchToProps = (dispatch) => {
@@ -72,6 +73,8 @@ const ExperimentFlowContainer = ({
   // CONSTANTS
   // getting experiment uuid
   const { projectId, experimentId } = useParams();
+  const transformations = useStoreState((store) => store.transform);
+  console.log(transformations);
 
   // HOOKS
   // did mount hook
@@ -102,6 +105,7 @@ const ExperimentFlowContainer = ({
       handleTaskBoxClick={selectOperatorHandler}
       handleDeselectOperator={handleDeselectOperator}
       handleSavePosition={handleSavePosition}
+      transformations={transformations}
     />
   );
 };

--- a/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/index.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/index.js
@@ -85,9 +85,15 @@ const ExperimentFlow = ({
   });
 
   const handleLoad = (reactFlowInstance) => {
-    handleSaveFlowTransform({ x: 0, y: 0, zoom: 1 });
-    reactFlowInstance.setTransform({ x: 0, y: 0, zoom: 1 });
+    setTimeout(() => {
+      reactFlowInstance.fitView();
+    }, 400);
   };
+
+  // const handleOnMove = (trans) => {
+  //   console.log('moveu', trans);
+  //   handleSaveFlowTransform(trans);
+  // };
 
   //TODO: Will be used later.
   const handleConnect = (params) =>
@@ -121,7 +127,7 @@ const ExperimentFlow = ({
         onNodeDragStop={handleDragStop}
         onConnectEnd={() => setConnectClass('')}
         onConnectStart={() => setConnectClass('Connecting')}
-        onMoveEnd={handleSaveFlowTransform}
+        // onMoveEnd={handleOnMove}
       >
         <Background
           variant='dots'
@@ -163,7 +169,13 @@ const ExperimentFlowDrop = DropTarget(
     drop: (props, monitor) => {
       const delta = monitor.getClientOffset();
 
-      const offset = props.flowTransform;
+      // const offset = props.flowTransform;
+
+      const offset = {
+        x: props.transformations[0],
+        y: props.transformations[1],
+        zoom: props.transformations[2],
+      };
 
       const positions = { x: delta.x - 435, y: delta.y - 189 };
 

--- a/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/index.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/index.js
@@ -40,7 +40,6 @@ const ExperimentFlow = ({
   handleTaskBoxClick,
   handleDeselectOperator,
   handleSavePosition,
-  handleSaveFlowTransform,
   canDrop,
   isOver,
   connectDropTarget,
@@ -87,13 +86,9 @@ const ExperimentFlow = ({
   const handleLoad = (reactFlowInstance) => {
     setTimeout(() => {
       reactFlowInstance.fitView();
-    }, 400);
+      reactFlowInstance.zoomTo(1);
+    }, 0);
   };
-
-  // const handleOnMove = (trans) => {
-  //   console.log('moveu', trans);
-  //   handleSaveFlowTransform(trans);
-  // };
 
   //TODO: Will be used later.
   const handleConnect = (params) =>
@@ -127,7 +122,6 @@ const ExperimentFlow = ({
         onNodeDragStop={handleDragStop}
         onConnectEnd={() => setConnectClass('')}
         onConnectStart={() => setConnectClass('Connecting')}
-        // onMoveEnd={handleOnMove}
       >
         <Background
           variant='dots'

--- a/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/index.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/index.js
@@ -86,7 +86,6 @@ const ExperimentFlow = ({
   const handleLoad = (reactFlowInstance) => {
     setTimeout(() => {
       reactFlowInstance.fitView();
-      reactFlowInstance.zoomTo(1);
     }, 0);
   };
 

--- a/src/components/Content/ProjectContent/Experiment/ExperimentHeader/ToolbarConfig/index.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentHeader/ToolbarConfig/index.js
@@ -19,7 +19,6 @@ import { useStoreActions } from 'react-flow-renderer';
 const ToolbarConfig = ({ handleDeleteClick, operator }) => {
   //ACTIONS FROM REACT FLOW RENDERER
   const fitView = useStoreActions((flowStore) => flowStore.fitView);
-  const zoomTo = useStoreActions((flowStore) => flowStore.zoomTo);
 
   //HANDLERS
   const handleZoomIn = useStoreActions((flowStore) => flowStore.zoomIn);
@@ -28,7 +27,6 @@ const ToolbarConfig = ({ handleDeleteClick, operator }) => {
 
   const handleFitView = () => {
     fitView();
-    zoomTo(1);
   };
 
   return (

--- a/src/components/Content/ProjectContent/Experiment/ExperimentHeader/ToolbarConfig/index.js
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentHeader/ToolbarConfig/index.js
@@ -9,17 +9,35 @@ import {
   DeleteOutlined,
   ZoomInOutlined,
   ZoomOutOutlined,
+  ExpandOutlined,
 } from '@ant-design/icons';
 
 import { Button, Popconfirm } from 'antd';
 
+import { useStoreActions } from 'react-flow-renderer';
+
 const ToolbarConfig = ({ handleDeleteClick, operator }) => {
+  //ACTIONS FROM REACT FLOW RENDERER
+  const fitView = useStoreActions((flowStore) => flowStore.fitView);
+  const zoomTo = useStoreActions((flowStore) => flowStore.zoomTo);
+
+  //HANDLERS
+  const handleZoomIn = useStoreActions((flowStore) => flowStore.zoomIn);
+
+  const handleZoomOut = useStoreActions((flowStore) => flowStore.zoomOut);
+
+  const handleFitView = () => {
+    fitView();
+    zoomTo(1);
+  };
+
   return (
     <>
       <Button icon={<UndoOutlined />} type='text' disabled />
       <Button icon={<RedoOutlined />} type='text' disabled />
-      <Button icon={<ZoomInOutlined />} type='text' disabled />
-      <Button icon={<ZoomOutOutlined />} type='text' disabled />
+      <Button icon={<ZoomInOutlined />} type='text' onClick={handleZoomIn} />
+      <Button icon={<ZoomOutOutlined />} type='text' onClick={handleZoomOut} />
+      <Button icon={<ExpandOutlined />} type='text' onClick={handleFitView} />
       <Popconfirm
         title='Você tem certeza que deseja excluir esta tarefa?'
         onConfirm={handleDeleteClick}

--- a/src/components/Content/ProjectContent/_/FlowDrop/index.js
+++ b/src/components/Content/ProjectContent/_/FlowDrop/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
+import { ReactFlowProvider } from 'react-flow-renderer';
 
 //COMPONENTS
 import ExperimentEmpty from '../../Experiment/ExperimentEmpty';
@@ -15,9 +16,11 @@ const FlowDrop = () => {
 
   return (
     <div className='custom-flow'>
-      <ExperimentHeader />
-      {experimentId ? <ExperimentFlow /> : <ExperimentEmpty />}
-      <CustomDragLayer />
+      <ReactFlowProvider>
+        <ExperimentHeader />
+        {experimentId ? <ExperimentFlow /> : <ExperimentEmpty />}
+        <CustomDragLayer />
+      </ReactFlowProvider>
     </div>
   );
 };


### PR DESCRIPTION
Use provider from react flow renderer to access zoom functions and use fitView when change between experiments.

Now we can: 
- click for zoom in/ou;
- fit view so that all operators are inside the view flow;
- when changing between experiments all operators are showed