### PR TITLE
Fix stroke color of connection line

### DIFF
--- a/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/style.less
+++ b/src/components/Content/ProjectContent/Experiment/ExperimentFlow/_/style.less
@@ -11,7 +11,7 @@
   }
   &.selected {
     .react-flow__edge-path {
-      stroke: #1890ff;
+      stroke: #1890ff !important;
       marker-end: url('#react-flow__arrowend-selected');
       marker-start: url('#react-flow__circle-selected');
     }


### PR DESCRIPTION
Need to add !important to stroke color of selected line, because we are changing style from original lib to match our platform style guide.