### PR TITLE
Adjusts responses to use new API responses for GET /resources

### DIFF
--- a/src/containers/DeploymentsTableContainer/DeploymentsTableContainer.jsx
+++ b/src/containers/DeploymentsTableContainer/DeploymentsTableContainer.jsx
@@ -1,11 +1,10 @@
 // CORE LIBS
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { useParams, withRouter } from 'react-router-dom';
 
 // COMPONENTS
 import DeploymentsTable from 'components/Content/ProjectDetailsContent/DeploymentsTable';
-import deploymentApi from 'services/DeploymentsApi';
 
 // ACTIONS
 import { getDeployExperimentLogs } from 'store/deploymentLogs/actions';
@@ -54,7 +53,6 @@ const DeploymentsTableContainer = (props) => {
     deployments
   } = props;
   const { projectId } = useParams();
-  const [deploymentsRuns, setDeploymentsRuns] = useState([]);
 
   useEffect(() => {
     // first get: when component has mounted
@@ -67,32 +65,6 @@ const DeploymentsTableContainer = (props) => {
     return () => clearInterval(polling);
   }, [projectId, handleFetchDeploymentsRequest]);
 
-  useEffect(() => {
-    const deployments_ = deployments.map((deployment) => {
-      return deploymentApi.getDeployment(projectId, deployment.uuid);
-    });
-
-    Promise.all(deployments_)
-    .then((respose) => {
-      const runs = respose.map((deployment) => {
-        // get only the properties that matter to the deployment runs table
-        const {
-          experimentId,
-          createdAt,
-          status,
-          runId,
-          uuid,
-          name,
-          url
-        } = deployment.data;
-        return { createdAt, uuid, experimentId, name, runId, status, url };
-      });
-
-      setDeploymentsRuns(runs);
-    })
-    .catch(() => {});
-  }, [deployments, projectId]);
-
   const deleteDeployment = (deployId) => {
     handleDeleteDeployment(projectId, deployId);
   };
@@ -104,7 +76,7 @@ const DeploymentsTableContainer = (props) => {
   return (
     <div className='deploymentsTableContainer'>
       <DeploymentsTable
-        deployments={deploymentsRuns}
+        deployments={deployments}
         loading={loading}
         onDeleteDeployment={deleteDeployment}
         onOpenLog={handleOpenLog}

--- a/src/store/compareResults/actions.js
+++ b/src/store/compareResults/actions.js
@@ -97,7 +97,7 @@ export const fetchCompareResults = (projectId, experiments) => {
     compareResultsApi
       .listCompareResult(projectId)
       .then(async (response) => {
-        const compareResults = response.data;
+        const compareResults = response.data.comparisons;
         dispatch(changeLoadingCompareResultsModal(false));
         dispatch({
           type: actionTypes.FETCH_COMPARE_RESULTS,

--- a/src/store/datasets/actions.js
+++ b/src/store/datasets/actions.js
@@ -71,7 +71,14 @@ export const fetchDatasetsRequest = () => (dispatch) => {
   datasetsApi
     .listDatasets()
     .then((response) => dispatch(fetchDatasetsSuccess(response)))
-    .catch((error) => dispatch(fetchDatasetsFail(error)));
+    .catch((error) => {
+      // allow to fail silently for 404
+      if (error.response.status === 404) {
+        dispatch(datasetsListDataLoaded());
+      } else {
+        dispatch(fetchDatasetsFail(error));
+      }
+    });
 };
 
 /**

--- a/src/store/deployments/actions.js
+++ b/src/store/deployments/actions.js
@@ -30,7 +30,7 @@ const fetchDeploymentsSuccess = (response) => (dispatch) => {
   // dispatching fetch deployments success action
   dispatch({
     type: actionTypes.FETCH_DEPLOYMENTS_SUCCESS,
-    deployments: response.data,
+    deployments: response.data.deployments,
   });
 };
 

--- a/src/store/experiments/actions.js
+++ b/src/store/experiments/actions.js
@@ -37,7 +37,7 @@ const ALREADY_EXIST_MESSAGE = 'Já existe um experimento com este nome!';
  */
 const fetchExperimentsSuccess = (response) => (dispatch) => {
   // getting experiments from response
-  const experiments = response.data;
+  const experiments = response.data.experiments;
 
   // dispatching experiments tabs data loaded action
   dispatch(experimentsTabsDataLoaded());

--- a/src/store/experiments/experimentRuns/actions.js
+++ b/src/store/experiments/experimentRuns/actions.js
@@ -116,8 +116,8 @@ const createExperimentRunSuccess = (projectId, routerProps, response) => (dispat
 
 /**
  * Create experiment run fail action
- * 
- * @param {object} error 
+ *
+ * @param {object} error
  * @returns {object} { type }
  */
 const createExperimentRunFail = (error) => (dispatch) => {
@@ -165,7 +165,7 @@ const createExperimentRunRequest = (projectId, experimentId, routerProps) => (di
  */
 const deleteExperimentRunSuccess = (response) => (dispatch) => {
   dispatch(implantedExperimentsLoadingData())
-  
+
   dispatch({
     type: actionTypes.DELETE_EXPERIMENT_RUN_SUCCESS,
     runs: []
@@ -176,8 +176,8 @@ const deleteExperimentRunSuccess = (response) => (dispatch) => {
 
 /**
  * Delete experiment run fail action
- * 
- * @param {object} error 
+ *
+ * @param {object} error
  * @returns {object} { type }
  */
 const deleteExperimentRunFail = (error) => (dispatch) => {
@@ -225,7 +225,7 @@ const deleteExperimentRunRequest = (projectId, experimentId) => (dispatch) => {
  */
 const fetchExperimentRunStatusSuccess = (response, experimentId) => (dispatch, getState) => {
   const { uiReducer } = getState();
-  const operators = response.data;
+  const operators = response.data.operators;
 
   let isRunning = false;
   let interruptExperiment = uiReducer.experimentTraining.deleteLoading;
@@ -238,11 +238,11 @@ const fetchExperimentRunStatusSuccess = (response, experimentId) => (dispatch, g
     const stoppedRun = operators.some((operator) => {
       return operator.status === 'Failed' || operator.status === 'Terminated';
     });
-    
+
     const isAllPending = operators.every((operator) => {
       return operator.status === 'Pending';
     });
-  
+
     if (isAllPending) {
       dispatch(experimentNameLoadingData());
     } else {
@@ -261,13 +261,13 @@ const fetchExperimentRunStatusSuccess = (response, experimentId) => (dispatch, g
       isRunning = false;
       const currentState = getState();
       const experimentsState = currentState.experimentsReducer;
-  
+
       const experiments = experimentsState.map((experiment) => {
         return experiment.uuid !== experimentId
           ? experiment
           : { ...experiment, succeded: true };
       });
-  
+
       dispatch({
         type: actionTypes.EXPERIMENT_RUN_SUCCEEDED,
         experiments
@@ -277,7 +277,7 @@ const fetchExperimentRunStatusSuccess = (response, experimentId) => (dispatch, g
     // experiment run has stopped
     if (!isRunning) {
       dispatch(experimentTrainingDataLoaded());
-  
+
       // check if was manual interrupted
       if (interruptExperiment) {
         dispatch(experimentDeleteTrainingDataLoaded());

--- a/src/store/operator/actions.js
+++ b/src/store/operator/actions.js
@@ -139,10 +139,13 @@ export const getOperatorFigures = (
     })
     .catch((error) => {
       dispatch(operatorResultsDataLoaded());
-      dispatch({
-        type: actionTypes.GET_OPERATOR_FIGURES_FAIL,
-      });
-      message.error(error.message);
+      // allowed to fail silently for 404
+      if (error.response.status !== 404) {
+        dispatch({
+          type: actionTypes.GET_OPERATOR_FIGURES_FAIL,
+        });
+        message.error(error.message);
+      }
     });
 };
 

--- a/src/store/operators/actions.js
+++ b/src/store/operators/actions.js
@@ -100,7 +100,7 @@ export const fetchOperatorsRequest = (projectId, experimentId) => async (
       projectId,
       experimentId
     );
-    const operators = operatorsResponse.data;
+    const operators = operatorsResponse.data.operators;
 
     // getting dataset columns
     const datasetName = utils.getDatasetName(tasks, operators);

--- a/src/store/projectDeployments/actions.js
+++ b/src/store/projectDeployments/actions.js
@@ -64,7 +64,7 @@ export const createProjectDeployment = (projectId, experimentId, name) => (
 
 /**
  * Delete deployment
- * 
+ *
  * @param {string} projectId Project uuid
  * @param {string} deploymentId Deployment uuid
  * @returns {Function} Dispatch function
@@ -99,7 +99,7 @@ export const deleteProjectDeployment = (projectId, deploymentId) => (
 
 /**
  * Fetch deployments
- * 
+ *
  * @param {string} projectId Project uuid
  * @returns {Function} Dispatch function
  */
@@ -112,7 +112,7 @@ export const fetchProjectDeployments = (projectId) => (dispatch) => {
     .listDeployments(projectId)
     .then((response) => {
       dispatch(deploymentsTabsDataLoaded());
-      const deployments = response.data;
+      const deployments = response.data.deployments;
       dispatch({
         type: actionTypes.FETCH_DEPLOYMENT_SUCCESS,
         deployments: deployments,
@@ -131,7 +131,7 @@ export const fetchProjectDeployments = (projectId) => (dispatch) => {
 
 /**
  * Update deployment position
- * 
+ *
  * @param {string} projectId Project uuid
  * @param {string} dragId Drag uuid
  * @param {string} hoverId Hover uuid

--- a/src/store/projects/actions.js
+++ b/src/store/projects/actions.js
@@ -50,7 +50,7 @@ export const fetchPaginatedProjects = (name, page, pageSize) => (dispatch) => {
 
 /**
  * Function to fetch all projects and dispatch to reducer
- * 
+ *
  * @returns {Function} The `disptach` function
  */
 export const fetchProjects = () => (dispatch) => {
@@ -58,7 +58,7 @@ export const fetchProjects = () => (dispatch) => {
   projectsApi
     .listProjects()
     .then((response) => {
-      const projects = response.data;
+      const projects = response.data.projects;
       dispatch(projectsTableDataLoaded());
       dispatch({
         type: actionTypes.FETCH_PROJECTS,

--- a/src/store/tasksMenu/actions.js
+++ b/src/store/tasksMenu/actions.js
@@ -76,8 +76,8 @@ export const fetchTasksMenuRequest = () => async (dispatch) => {
     let tasksMenu = {};
 
     // adding templates to menu
-    if (templatesResponse.data && templatesResponse.data.length > 0)
-      tasksMenu.TEMPLATES = templatesResponse.data;
+    if (templatesResponse.data.templates && templatesResponse.data.templates.length > 0)
+      tasksMenu.TEMPLATES = templatesResponse.data.templates;
 
     // adding tasks to menu
     tasksMenu = {

--- a/src/store/templates/actions.js
+++ b/src/store/templates/actions.js
@@ -29,14 +29,14 @@ import { fetchTasksMenuRequest } from '../tasksMenu/actions';
 // ** FETCH TEMPLATES
 /**
  * fetch templates success action
- * 
+ *
  * @param {Object} response Request response
  * @returns {Object} { type, templates }
  */
 const fetchTemplatesSuccess = (response) => (dispatch) => {
   dispatch({
     type: actionTypes.FETCH_TEMPLATES_SUCCESS,
-    templates: response.data,
+    templates: response.data.templates,
   });
 };
 
@@ -80,7 +80,7 @@ export const fetchTemplatesRequest = () => (dispatch) => {
 // ** CREATE TEMPLATE
 /**
  * create template success action
- * 
+ *
  * @param {Object} response
  * @returns {Object} { type, templates }
  */
@@ -103,7 +103,7 @@ const createTemplateSuccess = (response) => (dispatch) => {
 
 /**
  * create template fail action
- * 
+ *
  * @param {Object} error
  * @returns {Object} { type, errorMessage }
  */
@@ -125,7 +125,7 @@ const createTemplateFail = (error) => (dispatch) => {
 
 /**
  * create template request action
- * 
+ *
  * @param {string} templateName
  * @param {string} experimentId
  * @returns {Function}
@@ -153,7 +153,7 @@ export const createTemplateRequest = (templateName, experimentId) => (
 // ** UPDATE TEMPLATE
 /**
  * update template success action
- * 
+ *
  * @param {object} response Request response
  * @returns {object} {type, experiment}
  */
@@ -178,9 +178,9 @@ const updateTemplateSuccess = (response) => (
 
 /**
  * update template fail action
- * 
- * @param {object} error 
- * @returns {object} { type, errorMessage } 
+ *
+ * @param {object} error
+ * @returns {object} { type, errorMessage }
  */
 const updateTemplateFail = (error) => (dispatch) => {
   // getting error message
@@ -197,9 +197,9 @@ const updateTemplateFail = (error) => (dispatch) => {
 
 /**
  * update template request action
- * 
+ *
  * @param {string} templateId Template UUID
- * @param {string} templateName Template name 
+ * @param {string} templateName Template name
  * @returns {Function}
  */
 export const updateTemplateRequest = (
@@ -234,11 +234,11 @@ const deleteTemplateSuccess = (templateId, allTasks) => (
   const filteredTemplates = [...allTasks.filtered.TEMPLATES].filter(
     (template) => template.uuid !== templateId
   );
-    
+
   const unfilteredTemplates = [...allTasks.unfiltered.TEMPLATES].filter(
     (template) => template.uuid !== templateId
   );
-      
+
   const tasks = {
     unfiltered: {
       ...allTasks.unfiltered,
@@ -249,15 +249,15 @@ const deleteTemplateSuccess = (templateId, allTasks) => (
       TEMPLATES: filteredTemplates,
     },
   };
-      
+
   if (tasks.unfiltered.TEMPLATES.length === 0) {
     delete tasks.unfiltered.TEMPLATES;
   }
-  
+
   if (tasks.filtered.TEMPLATES.length === 0) {
     delete tasks.filtered.TEMPLATES;
   }
-      
+
   dispatch(tasksMenuDataLoaded());
 
   const currentState = getState();
@@ -266,42 +266,42 @@ const deleteTemplateSuccess = (templateId, allTasks) => (
   const templates = templatesState.filter((template) => {
     return template.uuid !== templateId;
   });
-  
+
   // dispatching delete template success action
   dispatch({
     type: actionTypes.DELETE_TEMPLATE_SUCCESS,
     payload: tasks,
     templates,
   });
-  
+
   message.success('Template excluído!');
 };
-    
+
 /**
  * delete template fail action
- * 
+ *
  * @param {Object} error
  * @returns {Object} { type, errorMessage }
  */
 const deleteTemplateFail = (error) => (dispatch) => {
   // getting error message
   const errorMessage = error.message;
-  
+
   // dispatching projects table data loaded action
   dispatch(tasksMenuDataLoaded());
-  
+
   // dispatching delete projects fail action
   dispatch({
     type: actionTypes.DELETE_TEMPLATE_FAIL,
     errorMessage,
   });
-  
+
   message.error(errorMessage);
 };
 
 /**
  * delete template request action
- * 
+ *
  * @param {string} templateId Template UUID
  * @param {*} allTasks
  * @returns {Function}
@@ -327,7 +327,7 @@ export const deleteTemplateRequest = (templateId, allTasks) => (dispatch) => {
 // ** SET TEMPLATE
 /**
  * set template success action
- * 
+ *
  * @param {object} response Request response
  * @param {string} projectId Project UUID
  * @param {string} experimentId Experiment UUID
@@ -351,7 +351,7 @@ const setTemplateSuccess = (response, projectId, experimentId) => (
 
 /**
  * set template fail action
- * 
+ *
  * @param {object} error
  * @returns {object} { type, errorMessage }
  */
@@ -372,7 +372,7 @@ const setTemplateFail = (error) => (dispatch) => {
 
 /**
  * set template request action
- * 
+ *
  * @param {string} projectId Project UUID
  * @param {string} experimentId Experiment UUID
  * @param {string} templateId Template UUID


### PR DESCRIPTION
GET templates, comparisons, experiments, deployments, and operators
now return an object {"resources": [], "total": num}