### PR TITLE
Remove history.push from createExperimentRunSuccess action

### DIFF
--- a/src/store/experiments/experimentRuns/actions.js
+++ b/src/store/experiments/experimentRuns/actions.js
@@ -110,7 +110,6 @@ const createExperimentRunSuccess = (projectId, routerProps, response) => (dispat
     runId: response.data.uuid
   });
 
-  routerProps.history.push(`/projetos/${projectId}/experimentos`);
   message.success('Treinamento iniciado!');
 };
 


### PR DESCRIPTION
In the createExperimentRunSuccess action, a history.push() was being made with an undefined experimentId, line removed