### PR TITLE
Sets a default value for client offset when x and y are undefined

### DIFF
--- a/src/components/Content/ExperimentsContent/Experiment/ExperimentFlow/_/index.js
+++ b/src/components/Content/ExperimentsContent/Experiment/ExperimentFlow/_/index.js
@@ -203,8 +203,8 @@ const ExperimentFlowDrop = DropTarget(
     },
     drop: (props, monitor) => {
       const delta = monitor.getClientOffset();
-
-      // const offset = props.flowTransform;
+      delta.x = delta.x ?? 435;
+      delta.y = delta.y ?? 189;
 
       const offset = {
         x: props.transformations[0],


### PR DESCRIPTION
Fix automation tests (when mouse position are not retrieved).