### PR TITLE
Returns the DEFAULT tagConfig when tag isn't defined in tagsConfig

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -268,7 +268,11 @@ const getTagConfig = (tag) => {
     TEMPLATES: { title: 'Templates', key: 'TEMPLATES', icon: <FileOutlined /> },
   };
 
-  return tagsConfig[tag];
+  if (tagsConfig[tag] !== undefined) {
+    return tagsConfig[tag];
+  }
+
+  return tagsConfig['DEFAULT'];
 };
 
 /**


### PR DESCRIPTION
Prevents error when backend returns an new/unknown tag.