### PR TITLE
Gets the correct attribute (columns) from datasetReducer

### DIFF
--- a/src/store/operators/actions.js
+++ b/src/store/operators/actions.js
@@ -206,13 +206,13 @@ export const upadteOperatorDependencies = (operators) => async (
   const { tasks } = tasksReducer;
 
   // getting dataset columns
-  const { datasetColumns } = datasetReducer;
+  const { columns } = datasetReducer;
 
   // configuring operators
   let configuredOperators = utils.configureOperators(
     tasks,
     operators,
-    datasetColumns
+    columns
   );
 
   // create/dispatch action


### PR DESCRIPTION
Replaces datasetColumns by columns, which is the correct name
of the attribute that holds the dataset columns.