### PR TITLE
Fix repeated item in the experiment task menu

### DIFF
--- a/src/components/Content/ExperimentsContent/TasksMenuBlock/TasksMenu/index.js
+++ b/src/components/Content/ExperimentsContent/TasksMenuBlock/TasksMenu/index.js
@@ -97,8 +97,12 @@ const TasksMenu = ({
   // sub menu
   const renderSubMenu = (submenu, items) => {
     // getting submenu config
-    const { icon, title, key } = utils.getTagConfig(submenu);
+    const tagConfig = utils.getTagConfig(submenu);
+    if (!tagConfig) return null
+
+    const { icon, title, key } = tagConfig
     templateValue = title;
+
     return (
       // sub menu component
       <SubMenu

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,6 @@ import {
   ReadOutlined,
   ShareAltOutlined,
   SolutionOutlined,
-  VideoCameraOutlined,
 } from '@ant-design/icons';
 
 /**
@@ -267,12 +266,6 @@ const getTagConfig = (tag) => {
     },
     // templates
     TEMPLATES: { title: 'Templates', key: 'TEMPLATES', icon: <FileOutlined /> },
-    // monitoring
-    MONITORING: {
-      title: 'Monitoramento',
-      key: 'MONITORING',
-      icon: <VideoCameraOutlined />,
-    }
   };
 
   if (tagsConfig[tag] !== undefined) {
@@ -664,8 +657,6 @@ const formatCompareResultDate = (date) => {
 /**
  * Format results parameters to use label from parameter and value from training
  *
- * @param parameters
- * @param parametersTraining
  * @param parameters
  * @param parametersTraining
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,7 @@ import {
   ReadOutlined,
   ShareAltOutlined,
   SolutionOutlined,
+  VideoCameraOutlined,
 } from '@ant-design/icons';
 
 /**
@@ -266,13 +267,19 @@ const getTagConfig = (tag) => {
     },
     // templates
     TEMPLATES: { title: 'Templates', key: 'TEMPLATES', icon: <FileOutlined /> },
+    // monitoring
+    MONITORING: {
+      title: 'Monitoramento',
+      key: 'MONITORING',
+      icon: <VideoCameraOutlined />,
+    }
   };
 
   if (tagsConfig[tag] !== undefined) {
     return tagsConfig[tag];
   }
 
-  return tagsConfig['DEFAULT'];
+  return null
 };
 
 /**
@@ -352,9 +359,9 @@ const configureOperatorParameters = (
   const datasetParameters =
     isDataset && operatorParameters
       ? Object.keys(operatorParameters).map((key) => ({
-          name: key,
-          value: operatorParameters[key],
-        }))
+        name: key,
+        value: operatorParameters[key],
+      }))
       : undefined;
 
   const configuredOperatorParameters = taskParameters.map((parameter) => {
@@ -656,6 +663,11 @@ const formatCompareResultDate = (date) => {
 
 /**
  * Format results parameters to use label from parameter and value from training
+ *
+ * @param parameters
+ * @param parametersTraining
+ * @param parameters
+ * @param parametersTraining
  */
 const formatResultsParameters = (parameters, parametersTraining) => {
   const resultsParameters = [];


### PR DESCRIPTION
- Return null if don't find a tag config
- Don't render SubMenu if tagConfig is falsy (null, undefined, empty string, etc)