### PR TITLE
Fix - Fetch tasks when render the ExperimentsContent/TasksMenuBlock

### DIFF
--- a/src/components/Content/ExperimentsContent/TasksMenuBlock/_/Container.js
+++ b/src/components/Content/ExperimentsContent/TasksMenuBlock/_/Container.js
@@ -16,10 +16,12 @@ import {
   setTemplateRequest,
   deleteTemplateRequest,
 } from '../../../../../store/templates/actions';
+import { fetchTasks } from 'store/tasks/actions';
 
 // DISPATCHS
 const mapDispatchToProps = (dispatch) => {
   return {
+    handleFetchTasks: () => dispatch(fetchTasks()),
     handleFetchTasksMenu: () => dispatch(fetchTasksMenuRequest()),
     handleFilterTasksMenu: (filter) => dispatch(filterTasksMenu(filter)),
     handleCreateOperator: (
@@ -69,6 +71,7 @@ const TasksMenuBlockContainer = ({
   trainingLoading,
   trainingSucceeded,
   tasksMenu,
+  handleFetchTasks,
   handleFetchTasksMenu,
   handleFilterTasksMenu,
   handleCreateOperator,
@@ -85,8 +88,9 @@ const TasksMenuBlockContainer = ({
   // did mount hook
   useEffect(() => {
     // fetching menu tasks
+    handleFetchTasks()
     handleFetchTasksMenu();
-  }, [handleFetchTasksMenu]);
+  }, [handleFetchTasks, handleFetchTasksMenu]);
 
   // HANDLERS
   const createOperatorHandler = (taskId, taskType, position) => {


### PR DESCRIPTION
- Fetch tasks when you open the experiment page (when TasksMenuBlock renders)

If do not load the tasks the user cannot drag and drop a task in the flow area.