### PR TITLE
Fix - Experimentation Tabs Popovers

### DIFF
--- a/src/components/Content/ExperimentsContent/ExperimentsTabs/_/Container.js
+++ b/src/components/Content/ExperimentsContent/ExperimentsTabs/_/Container.js
@@ -14,16 +14,30 @@ import { deselectOperator } from 'store/operator/actions';
 // DISPATCHS
 const mapDispatchToProps = (dispatch, routerProps) => {
   return {
-    handleClearAllExperiments: () => dispatch(experimentsActions.clearAllExperiments()),
+    handleClearAllExperiments: () =>
+      dispatch(experimentsActions.clearAllExperiments()),
     handleFetchExperiments: (projectId) =>
-      dispatch(experimentsActions.fetchExperimentsRequest(projectId, routerProps)),
+      dispatch(
+        experimentsActions.fetchExperimentsRequest(projectId, routerProps)
+      ),
     handleFetchExperiment: (projectId, experimentId) =>
       dispatch(experimentsActions.activeExperiment(projectId, experimentId)),
     handleDeleteExperiment: (projectId, experimentId) =>
-      dispatch(experimentsActions.deleteExperimentRequest(projectId, experimentId, routerProps)),
+      dispatch(
+        experimentsActions.deleteExperimentRequest(
+          projectId,
+          experimentId,
+          routerProps
+        )
+      ),
     handleRenameExperiment: (projectId, experimentId, newName) =>
       dispatch(
-        experimentsActions.updateExperimentName(projectId, experimentId, newName, routerProps)
+        experimentsActions.updateExperimentName(
+          projectId,
+          experimentId,
+          newName,
+          routerProps
+        )
       ),
     handleDuplicateExperiment: (projectId, experimentId, newName) =>
       dispatch(
@@ -98,7 +112,7 @@ const ExperimentTabsContainer = (props) => {
   useEffect(() => {
     // fetching projects
     handleFetchExperiments(projectId);
-  }, [handleFetchExperiments, projectId, handleClearAllExperiments]);
+  }, [handleFetchExperiments, projectId]);
 
   useEffect(() => {
     return () => {

--- a/src/components/Content/ExperimentsContent/ExperimentsTabs/_/index.js
+++ b/src/components/Content/ExperimentsContent/ExperimentsTabs/_/index.js
@@ -1,5 +1,5 @@
 // CORE LIBS
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Popconfirm, Popover, Input } from 'antd';
 import { ContextMenu, MenuItem, ContextMenuTrigger } from 'react-contextmenu';
@@ -30,6 +30,9 @@ const ExperimentsTabs = ({
   const [isDuplicating, setIsDuplicating] = useState(false);
   const [selectedExperimentId, setSelectedExperimentId] = useState(null);
 
+  const renamingInputRef = useRef(null);
+  const duplicatingInputRef = useRef(null);
+
   const handleShowRenamingPopover = (id, name) => {
     setSelectedExperimentId(id);
     setExperimentName(name);
@@ -53,6 +56,18 @@ const ExperimentsTabs = ({
     if (name.length > 0) {
       setIsRenaming(false);
       renameHandler(selectedExperimentId, name);
+    }
+  };
+
+  const handleFocusRenamingPopover = (isVisible) => {
+    if (renamingInputRef.current && isVisible) {
+      renamingInputRef.current.focus();
+    }
+  };
+
+  const handleFocusDuplicatingPopover = (isVisible) => {
+    if (duplicatingInputRef.current && isVisible) {
+      duplicatingInputRef.current.focus();
     }
   };
 
@@ -132,10 +147,12 @@ const ExperimentsTabs = ({
           trigger='click'
           visible={isRenaming}
           onVisibleChange={setIsRenaming}
+          afterVisibleChange={handleFocusRenamingPopover}
           content={
             <>
               <p>Renomear</p>
               <Input.Search
+                ref={renamingInputRef}
                 enterButton='Ok'
                 onSearch={handleConfirmRenaming}
                 placeholder='Digite o novo nome'
@@ -168,10 +185,12 @@ const ExperimentsTabs = ({
           trigger='click'
           visible={isDuplicating}
           onVisibleChange={setIsDuplicating}
+          afterVisibleChange={handleFocusDuplicatingPopover}
           content={
             <>
               <p>Duplicar</p>
               <Input.Search
+                ref={duplicatingInputRef}
                 enterButton='Ok'
                 placeholder='Digite o novo nome'
                 loading={loading}

--- a/src/components/Content/ExperimentsContent/ExperimentsTabs/_/index.js
+++ b/src/components/Content/ExperimentsContent/ExperimentsTabs/_/index.js
@@ -30,15 +30,15 @@ const ExperimentsTabs = ({
   const [isDuplicating, setIsDuplicating] = useState(false);
   const [selectedExperimentId, setSelectedExperimentId] = useState(null);
 
-  const handleShowRenamingPopover = (experimentId, experimentName) => {
-    setSelectedExperimentId(experimentId);
-    setExperimentName(experimentName);
+  const handleShowRenamingPopover = (id, name) => {
+    setSelectedExperimentId(id);
+    setExperimentName(name);
     setIsRenaming(true);
   };
 
-  const handleShowDuplicatingPopover = (experimentId, experimentName) => {
-    setSelectedExperimentId(experimentId);
-    setExperimentName(experimentName);
+  const handleShowDuplicatingPopover = (id, name) => {
+    setSelectedExperimentId(id);
+    setExperimentName(name);
     setIsDuplicating(true);
   };
 


### PR DESCRIPTION
- **Error**: When open the popover to rename or duplicate experiment they close after some seconds.
- **Problem**: The operator polling request make the popovers to close.
- **Solution**: Close the popover when click in the `OK` button.