### PR TITLE
Fix - Two HTML5 Backends Error

### DIFF
--- a/src/components/Content/ExperimentsContent/_/index.js
+++ b/src/components/Content/ExperimentsContent/_/index.js
@@ -1,14 +1,15 @@
 // CORE LIBS
 import React from 'react';
+import { Layout } from 'antd';
 import { useParams } from 'react-router-dom';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
 
 // COMPONENTS
 import TasksMenuBlock from '../TasksMenuBlock/_/Container';
 import ExperimentsTabs from '../ExperimentsTabs/_/Container';
 import NewExperimentButton from '../NewExperimentButton/Container';
 import NewExperimentModal from '../NewExperimentModal/Container';
+import CustomDndProvider from 'components/CustomDndProvider';
+import FlowDrop from './FlowDrop';
 
 import {
   ChangeRoutePromptContainer,
@@ -20,9 +21,6 @@ import {
   PrepareDeploymentsModalContainer,
 } from 'containers';
 
-import FlowDrop from './FlowDrop';
-
-import { Layout } from 'antd';
 import './style.less';
 
 const { Footer, Sider, Content } = Layout;
@@ -56,7 +54,7 @@ const ExperimentsContent = () => {
   // RENDER
   return (
     <>
-      <DndProvider backend={HTML5Backend}>
+      <CustomDndProvider>
         <PrepareDeploymentsModalContainer />
         <CompareResultsModalContainer />
         <DataViewModalContainer />
@@ -64,7 +62,7 @@ const ExperimentsContent = () => {
         <ExperimentsHeaderContainer />
         {renderFlowContent()}
         <ChangeRoutePromptContainer />
-      </DndProvider>
+      </CustomDndProvider>
     </>
   );
 };

--- a/src/components/CustomDndProvider/CustomDndProvider.component.jsx
+++ b/src/components/CustomDndProvider/CustomDndProvider.component.jsx
@@ -1,0 +1,23 @@
+import React, { useRef } from 'react';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { DndProvider, createDndContext } from 'react-dnd';
+
+const RNDContext = createDndContext(HTML5Backend);
+
+const useDNDProviderElement = (props) => {
+  const manager = useRef(RNDContext);
+  if (!props.children) return null;
+
+  return (
+    <DndProvider manager={manager.current.dragDropManager}>
+      {props.children}
+    </DndProvider>
+  );
+};
+
+const CustomDndProvider = (props) => {
+  const DNDElement = useDNDProviderElement(props);
+  return <>{DNDElement}</>;
+};
+
+export default CustomDndProvider;

--- a/src/components/CustomDndProvider/index.js
+++ b/src/components/CustomDndProvider/index.js
@@ -1,0 +1,3 @@
+import CustomDndProvider from './CustomDndProvider.component';
+
+export default CustomDndProvider;

--- a/src/components/TabsBar/Tabs/Tabs.component.jsx
+++ b/src/components/TabsBar/Tabs/Tabs.component.jsx
@@ -2,8 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ContextMenu, MenuItem, ContextMenuTrigger } from 'react-contextmenu';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
 
 // UI LIBS
 import {
@@ -17,6 +15,7 @@ import { Tabs as antdTabs, Popconfirm, Popover, Input } from 'antd';
 
 // COMPONENTS
 import DraggableTabs from '../DraggableTabs';
+import CustomDndProvider from 'components/CustomDndProvider';
 
 // TABS COMPONENTS
 const { TabPane } = antdTabs;
@@ -200,7 +199,7 @@ const Tabs = (props) => {
 
   return (
     <>
-      <DndProvider backend={HTML5Backend}>
+      <CustomDndProvider>
         <DraggableTabs
           activeTab={activeTab}
           onChange={onChange}
@@ -266,7 +265,7 @@ const Tabs = (props) => {
             </MenuItem>
           </Popconfirm>
         </ContextMenu>
-      </DndProvider>
+      </CustomDndProvider>
     </>
   );
 };


### PR DESCRIPTION
**Description**
- The error was discovered by @schafferjrdev -> https://github.com/platiagro/web-ui/pull/393#issuecomment-820444861.

**Solution**
- I found [THIS SOLUTION](https://github.com/react-dnd/react-dnd/issues/186#issuecomment-561631584) in the `react-dnd` repository.
- To solve the problem a custom `DndProvider` was created. This component is located at `src/components/CustomDndProvider`.

**IMPORTANT**
Anywhere else on this site where you need a DndProvider, you must use CutomDndProvider to prevent the same error from happening again. 