### PR TITLE
Handles new response body for createDeployment/duplicateDeployment

### DIFF
--- a/src/containers/DeploymentsTableContainer/DeploymentsTableContainer.jsx
+++ b/src/containers/DeploymentsTableContainer/DeploymentsTableContainer.jsx
@@ -19,7 +19,7 @@ const deploymentsSelector = ({ deploymentsReducer }) => {
   const deployments = deploymentsReducer || [];
   // filters by deployments that have an URL
   // ensures only items that are actually deployed are shown
-  return deployments.filter((deployment) => deployment.url != null);
+  return deployments.filter((deployment) => !!deployment.url);
 };
 
 const isLoadingSelector = ({ uiReducer }) => {

--- a/src/containers/DeploymentsTableContainer/DeploymentsTableContainer.jsx
+++ b/src/containers/DeploymentsTableContainer/DeploymentsTableContainer.jsx
@@ -53,12 +53,16 @@ const DeploymentsTableContainer = () => {
   };
 
   const handleTestImplantedExperimentInference = (
-    projectId,
+    currentProjectId,
     deploymentId,
     file
   ) => {
     dispatch(
-      testImplantedExperimentInferenceAction(projectId, deploymentId, file)
+      testImplantedExperimentInferenceAction(
+        currentProjectId,
+        deploymentId,
+        file
+      )
     );
   };
 

--- a/src/store/deployments/actions.js
+++ b/src/store/deployments/actions.js
@@ -386,7 +386,7 @@ export const prepareDeployments = (experiments, projectId, routerProps) => (
     .then(() => {
       dispatch(prepareDeploymentsDataLoaded());
 
-      routerProps.history.push(`/projetos/${projectId}`);
+      routerProps.history.push(`/projetos/${projectId}/pre-implantacao`);
       message.success('Experimento implantado!');
     })
     .catch((error) => {

--- a/src/store/deployments/actions.js
+++ b/src/store/deployments/actions.js
@@ -6,7 +6,6 @@ import actionTypes from './actionTypes';
 
 // SERVICE
 import deploymentsApi from 'services/DeploymentsApi';
-import deploymentsRunsApi from 'services/DeploymentRunsApi';
 
 // UI ACTIONS
 import {
@@ -324,38 +323,6 @@ export const clearAllDeployments = () => (dispatch) => {
   dispatch({
     type: actionTypes.CLEAR_ALL_DEPLOYMENTS,
   });
-};
-
-/** FIXME: Temporary solution to get all deployments runs
- *
- * On future need to be substituted by data normalization
- * on deployment reducer
- */
-
-export const fetchAllDeploymentsRuns = (
-  projectId,
-  experiments,
-  isToShowLoader
-) => async (dispatch) => {
-  if (isToShowLoader) {
-    dispatch(implantedExperimentsLoadingData());
-  }
-
-  const deployments = [];
-
-  if (experiments && experiments.length > 0) {
-    for (const experiment of experiments) {
-      await deploymentsRunsApi
-        .fetchDeploymentRuns(projectId, experiment.uuid)
-        .then((response) => {
-          deployments.push(response.data);
-        })
-        .catch(() => {});
-    }
-  }
-  dispatch(implantedExperimentsDataLoaded());
-
-  return deployments;
 };
 
 /**

--- a/src/store/deployments/actions.js
+++ b/src/store/deployments/actions.js
@@ -96,7 +96,7 @@ const createDeploymentSuccess = (response) => (dispatch) => {
   // dispatching create deployment success
   dispatch({
     type: actionTypes.CREATE_DEPLOYMENT_SUCCESS,
-    deployment: response.data,
+    deployments: response.data.deployments,
   });
 
   dispatch(newDeploymentModalEndLoading());
@@ -484,18 +484,13 @@ export function duplicateDeploymentRequest(
     try {
       dispatch({ type: actionTypes.DUPLICATE_DEPLOYMENT_REQUEST });
 
-      // TODO ------------------------------------------------------------------
-      // Isso não vai funcionar porque está passando ID de deployment ao
-      // invés de um ID de experiment. Para funcionar tem que fazer um outro
-      // endpoint na API.
-      // Esse novo endpoint tem também que receber um novo nome para o deployment.
       const response = await deploymentsApi.createDeployment(projectId, {
-        newDeploymentName,
-        experiments: [duplicatedDeploymentId],
+        name: newDeploymentName,
+        copyFrom: duplicatedDeploymentId,
       });
 
-      const [createdDeployment] = response.data;
-      dispatch(duplicateDeploymentSuccess(createdDeployment));
+      const deployments = response.data.deployments;
+      dispatch(duplicateDeploymentSuccess(deployments));
     } catch (error) {
       dispatch(duplicateDeploymentFail(error));
     }
@@ -505,14 +500,14 @@ export function duplicateDeploymentRequest(
 /**
  * Action to duplicate deployment success
  *
- * @param {object[]} duplicatedDeployment Duplicated deployment
+ * @param {object[]} deployments Duplicated deployment
  *
  * @returns {object} Action payload
  */
-function duplicateDeploymentSuccess(duplicatedDeployment) {
+function duplicateDeploymentSuccess(deployments) {
   return {
     type: actionTypes.DUPLICATE_DEPLOYMENT_SUCCESS,
-    deployment: duplicatedDeployment,
+    deployments: deployments,
   };
 }
 

--- a/src/store/deployments/deploymentsReducer.js
+++ b/src/store/deployments/deploymentsReducer.js
@@ -23,7 +23,7 @@ const deploymentsReducer = (state = initialState, action = undefined) => {
       return action.deployments;
     case actionTypes.DUPLICATE_DEPLOYMENT_SUCCESS:
     case actionTypes.CREATE_DEPLOYMENT_SUCCESS:
-      return [...state, action.deployment];
+      return [...state, ...action.deployments];
     // update deployment success
     case actionTypes.UPDATE_DEPLOYMENT_SUCCESS:
       return action.deployments;


### PR DESCRIPTION
Now a list of deployments is returned, since you can create multiple
deployments in a single request (by informing a list of experiments).
Further details are in the docs:
https://platiagro.github.io/projects/#/Deployments/post_projects__projectId__deployments