### PR TITLE
 Removes tasks.containerState occurrences

### DIFF
--- a/src/components/Content/TasksContent/TasksTable/TasksTableContainer.js
+++ b/src/components/Content/TasksContent/TasksTable/TasksTableContainer.js
@@ -9,7 +9,6 @@ import {
   fetchTasks,
   showEditTaskModal,
   showCopyTasksModal,
-  getContainerState,
 } from 'store/tasks';
 
 import TasksTable from './index';
@@ -24,7 +23,6 @@ const tasksSelector = ({ tasksReducer }) => {
 const TasksTableContainer = () => {
   const dispatch = useDispatch();
 
-  const containerState = useSelector(getContainerState);
   const tasks = useSelector(tasksSelector);
 
   const isLoadingOrDeleting = useIsLoading(
@@ -59,7 +57,6 @@ const TasksTableContainer = () => {
       <TasksTable
         tasks={tasks}
         loading={isLoadingOrDeleting}
-        containerState={containerState}
         handleClickTask={handleClickTask}
         handleClickDelete={handleDeleteTask}
         handleClickEdit={handleShowEditTaskModal}

--- a/src/components/Content/TasksContent/TasksTable/index.js
+++ b/src/components/Content/TasksContent/TasksTable/index.js
@@ -39,7 +39,6 @@ const { Text } = Typography;
  */
 const TasksTable = (props) => {
   const {
-    containerState,
     handleClickTask,
     handleClickEdit,
     handleClickDelete,
@@ -217,7 +216,6 @@ const TasksTable = (props) => {
         <Space size={8}>
           <Button
             className='btnTaskActions'
-            disabled={!containerState}
             onClick={() => handleClickTask(record.name)}
             type='link'
           >
@@ -284,8 +282,6 @@ const TasksTable = (props) => {
 
 // PROP TYPES
 TasksTable.propTypes = {
-  /** notebook server container state */
-  containerState: PropTypes.bool.isRequired,
   /** tasks table click task handle */
   handleClickTask: PropTypes.func.isRequired,
   /** tasks table click edit handle */

--- a/src/store/tasks/tasks.actions.js
+++ b/src/store/tasks/tasks.actions.js
@@ -208,14 +208,12 @@ export const fetchPaginatedTasks = (page, pageSize) => async (dispatch) => {
 /**
  * Fetch tasks success action creator
  *
- * @param {string} containerState Container state
  * @param {Array} tasks Tasks array
  * @returns {object} Action
  */
-export const fetchTasksSuccess = (containerState, tasks) => {
+export const fetchTasksSuccess = (tasks) => {
   return {
     type: TASKS_TYPES.FETCH_TASKS_SUCCESS,
-    containerState,
     tasks,
   };
 };
@@ -241,8 +239,8 @@ export const fetchTasks = (filters) => async (dispatch) => {
   try {
     dispatch(addLoading(TASKS_TYPES.FETCH_TASKS_REQUEST));
     const response = await tasksApi.getAllTasks(filters);
-    const { containerState, tasks } = response.data;
-    dispatch(fetchTasksSuccess(containerState, tasks));
+    const { tasks } = response.data;
+    dispatch(fetchTasksSuccess(tasks));
   } catch (e) {
     dispatch(fetchTasksFail());
     dispatch(showError(e.message));

--- a/src/store/tasks/tasks.reducer.js
+++ b/src/store/tasks/tasks.reducer.js
@@ -1,7 +1,6 @@
 import * as TASKS_TYPES from './tasks.actionTypes';
 
 export const initialState = {
-  containerState: false,
   editModalIsVisible: false,
   errorMessage: null,
   modalIsVisible: false,
@@ -59,7 +58,6 @@ export const tasksReducer = (state = initialState, action = {}) => {
     case TASKS_TYPES.FETCH_TASKS_SUCCESS: {
       return {
         ...state,
-        containerState: action.containerState,
         tasks: action.tasks,
       };
     }

--- a/src/store/tasks/tasks.selectors.js
+++ b/src/store/tasks/tasks.selectors.js
@@ -1,7 +1,3 @@
-export const getContainerState = ({ tasksReducer }) => {
-  return tasksReducer.containerState;
-};
-
 export const getEditModalIsVisible = ({ tasksReducer }) => {
   return tasksReducer.editModalIsVisible;
 };


### PR DESCRIPTION
This feature disabled the link to JupyterLab when containerState
was false. However, we have improved the link to JupyterLab with a
loading screen and disabling the button no longer makes sense.