### PR TITLE
Fix - Deployment Page Responsiveness

### DIFF
--- a/src/Pages/Deployment/Deployment.style.less
+++ b/src/Pages/Deployment/Deployment.style.less
@@ -22,7 +22,7 @@
 
       .deployment-page-body-flow {
         flex: 1;
-        min-height: 500px;
+        min-height: 150px;
         background-color: mintcream;
       }
 

--- a/src/components/LogListItem/LogListItem.component.jsx
+++ b/src/components/LogListItem/LogListItem.component.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import {
   BugOutlined,
@@ -57,4 +57,4 @@ LogListItem.defaultProps = {
   text: '',
 };
 
-export default LogListItem;
+export default memo(LogListItem);

--- a/src/components/LogListItem/styles.less
+++ b/src/components/LogListItem/styles.less
@@ -12,6 +12,10 @@
       font-weight: bold;
       margin-bottom: 3px;
     }
+
+    .log-list-item-content-text {
+      word-break: break-word;
+    }
   }
 
   &.error-log {

--- a/src/components/LogsPanel/styles.less
+++ b/src/components/LogsPanel/styles.less
@@ -27,7 +27,6 @@
 
   .logs-panel-logs {
     max-height: 250px;
-    overflow-x: hidden;
     overflow-y: auto;
   }
 

--- a/src/components/LogsPanel/styles.less
+++ b/src/components/LogsPanel/styles.less
@@ -26,7 +26,7 @@
   }
 
   .logs-panel-logs {
-    max-height: 250px;
+    max-height: 200px;
     overflow-y: auto;
   }
 

--- a/src/components/MonitoringFlowBox/MonitoringFlowBox.component.jsx
+++ b/src/components/MonitoringFlowBox/MonitoringFlowBox.component.jsx
@@ -1,10 +1,5 @@
-/* eslint-disable */
-
-// CORE LIBS
 import React from 'react';
 import PropTypes from 'prop-types';
-
-// UI LIBS
 import {
   CheckCircleFilled,
   ClockCircleFilled,
@@ -12,7 +7,6 @@ import {
   FundOutlined,
 } from '@ant-design/icons';
 
-// STYLES
 import './MonitoringFlowBox.style.less';
 
 const statusFlowBox = {
@@ -24,17 +18,12 @@ const statusFlowBox = {
   default: null,
 };
 
-/**
- * Componente de caixa (operador) de monitoramento.
- */
-function MonitoringFlowBox(props) {
+const MonitoringFlowBox = (props) => {
   const { title, status, onClick } = props;
-
   const statusIcon = statusFlowBox[status];
 
-  // RENDER
   return (
-    <div className='monitoring-flow-box' onClick={onClick}>
+    <button className='monitoring-flow-box' onClick={onClick}>
       <div className='monitoring-flow-box-circle' />
       <div className='monitoring-flow-box-line' />
       <div className='monitoring-flow-box-content'>
@@ -44,14 +33,12 @@ function MonitoringFlowBox(props) {
         <div className='monitoring-flow-box-title'>{title}</div>
         <div className='monitoring-flow-box-status'>{statusIcon}</div>
       </div>
-    </div>
+    </button>
   );
-}
+};
 
 MonitoringFlowBox.propTypes = {
-  /** Título do operador (caixa) */
   title: PropTypes.string.isRequired,
-  /** Estado do operador */
   status: PropTypes.oneOf([
     undefined,
     'pending',
@@ -61,7 +48,6 @@ MonitoringFlowBox.propTypes = {
     'disable',
     'default',
   ]),
-  /** Evento de click */
   onClick: PropTypes.func,
 };
 
@@ -70,5 +56,4 @@ MonitoringFlowBox.defaultProps = {
   onClick: undefined,
 };
 
-// EXPORT
 export default MonitoringFlowBox;

--- a/src/components/MonitoringFlowBox/MonitoringFlowBox.style.less
+++ b/src/components/MonitoringFlowBox/MonitoringFlowBox.style.less
@@ -1,6 +1,16 @@
 .monitoring-flow-box {
   display: flex;
   align-items: center;
+  outline: none;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover {
+    .monitoring-flow-box-content {
+      border: 2px dashed #747474;
+    }
+  }
 
   .monitoring-flow-box-circle {
     height: 16px;

--- a/src/components/MonitoringToolbar/MonitoringToolbar.component.jsx
+++ b/src/components/MonitoringToolbar/MonitoringToolbar.component.jsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react'
-import PropTypes from 'prop-types'
-import { Divider, Popconfirm, Typography } from 'antd'
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Divider, Popconfirm, Typography } from 'antd';
 import {
   PlusOutlined,
   FundOutlined,
   DeleteOutlined,
   DownOutlined,
   UpOutlined,
-} from '@ant-design/icons'
+} from '@ant-design/icons';
 
-import { Button } from 'uiComponents'
+import { Button } from 'uiComponents';
 
-import './styles.less'
+import './styles.less';
 
 const MonitoringToolbar = ({
   className,
@@ -27,94 +27,100 @@ const MonitoringToolbar = ({
 }) => {
   const [
     isShowingDeleteConfirmation,
-    setIsShowingDeleteConfirmation
-  ] = useState(false)
+    setIsShowingDeleteConfirmation,
+  ] = useState(false);
 
   const handleToggleDeleteConfirmation = () => {
-    setIsShowingDeleteConfirmation((isShowing) => !isShowing)
-  }
+    setIsShowingDeleteConfirmation((isShowing) => !isShowing);
+  };
 
   const handleDeleteMonitoringAndHideConfirmation = () => {
-    setIsShowingDeleteConfirmation(false)
-    if (handleDeleteMonitoring) handleDeleteMonitoring()
-  }
+    setIsShowingDeleteConfirmation(false);
+    if (handleDeleteMonitoring) handleDeleteMonitoring();
+  };
 
   useEffect(() => {
-    // Hides the delete confirmation modal if the delete button 
+    // Hides the delete confirmation modal if the delete button
     // or the panel is hidden
     if (!showDeleteButton || !isShowingPanel) {
-      setIsShowingDeleteConfirmation(false)
+      setIsShowingDeleteConfirmation(false);
     }
-  }, [isShowingPanel, showDeleteButton])
+  }, [isShowingPanel, showDeleteButton]);
 
   return (
     <div className={`monitoring-toolbar ${className}`}>
-      <Typography.Title className="toolbar-title" level={4}>
+      <Typography.Title className='monitoring-toolbar-title' level={4}>
         Monitoramentos
       </Typography.Title>
 
       {showAddButton && (
         <Button
-          shape="round"
-          type="primary-inverse"
+          className='monitoring-toolbar-add-button'
+          shape='round'
+          type='primary-inverse'
           icon={<PlusOutlined />}
-          handleClick={handleAddMonitoring}>
-          Adicionar
+          handleClick={handleAddMonitoring}
+        >
+          <span className='monitoring-toolbar-button-text'>Adicionar</span>
         </Button>
       )}
 
       {showSeeButton && (
         <>
-          <Divider className="toolbar-divider" type="vertical" />
+          <Divider className='monitoring-toolbar-divider' type='vertical' />
 
           <Button
-            shape="round"
-            type="primary-inverse"
+            className='monitoring-toolbar-see-button'
+            shape='round'
+            type='primary-inverse'
             icon={<FundOutlined />}
-            handleClick={handleSeeMonitoring}>
-            Ver Monitoramento
+            handleClick={handleSeeMonitoring}
+          >
+            <span className='monitoring-toolbar-button-text'>
+              Ver Monitoramento
+            </span>
           </Button>
         </>
       )}
 
       {showDeleteButton && (
         <>
-          <Divider className="toolbar-divider" type="vertical" />
+          <Divider className='monitoring-toolbar-divider' type='vertical' />
 
           <Popconfirm
             onConfirm={handleDeleteMonitoringAndHideConfirmation}
             onCancel={handleToggleDeleteConfirmation}
             visible={isShowingDeleteConfirmation}
-            title="Excluir o Monitoramento Selecionado?"
-            placement="topLeft"
-            cancelText="Cancelar"
-            okText="Excluir"
-            okType="danger"
+            title='Excluir o Monitoramento Selecionado?'
+            placement='topLeft'
+            cancelText='Cancelar'
+            okText='Excluir'
+            okType='danger'
           >
             <Button
-              shape="round"
-              type="primary-inverse"
+              className='monitoring-toolbar-delete-button'
+              shape='round'
+              type='primary-inverse'
               icon={<DeleteOutlined />}
               handleClick={handleToggleDeleteConfirmation}
               isLoading={isDeleting}
             >
-              Excluir
+              <span className='monitoring-toolbar-button-text'>Excluir</span>
             </Button>
           </Popconfirm>
         </>
-      )
-      }
+      )}
 
       <Button
-        className="toolbar-toggle-button"
-        shape="circle"
-        type="ghost"
+        className='monitoring-toolbar-toggle-button'
+        shape='circle'
+        type='ghost'
         icon={isShowingPanel ? <UpOutlined /> : <DownOutlined />}
-        handleClick={handleTogglePanel}>
-      </Button>
+        handleClick={handleTogglePanel}
+      ></Button>
     </div>
-  )
-}
+  );
+};
 
 MonitoringToolbar.propTypes = {
   className: PropTypes.string,
@@ -127,7 +133,7 @@ MonitoringToolbar.propTypes = {
   isShowingPanel: PropTypes.bool,
   handleTogglePanel: PropTypes.func,
   isDeleting: PropTypes.bool,
-}
+};
 
 MonitoringToolbar.defaultProps = {
   className: '',
@@ -139,7 +145,7 @@ MonitoringToolbar.defaultProps = {
   showDeleteButton: false,
   isShowingPanel: true,
   handleTogglePanel: undefined,
-  isDeleting: false
-}
+  isDeleting: false,
+};
 
-export default MonitoringToolbar
+export default MonitoringToolbar;

--- a/src/components/MonitoringToolbar/styles.less
+++ b/src/components/MonitoringToolbar/styles.less
@@ -4,18 +4,46 @@
   align-items: center;
   padding: 8px 16px;
 
-  .toolbar-title {
+  .monitoring-toolbar-title {
     margin: 0;
     margin-right: 16px;
   }
 
-  .toolbar-divider {
+  .monitoring-toolbar-divider {
     margin: 0 8px;
   }
 
-  .toolbar-toggle-button {
+  .monitoring-toolbar-toggle-button {
     margin-left: auto;
     height: 40px;
     width: 40px;
+  }
+
+  @media only screen and (max-width: 768px) {
+    .monitoring-toolbar-add-button,
+    .monitoring-toolbar-see-button,
+    .monitoring-toolbar-delete-button {
+      height: 40px;
+      width: 40px;
+      padding: 0;
+
+      .monitoring-toolbar-button-text {
+        display: none;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 500px) {
+    .monitoring-toolbar-divider {
+      display: none;
+    }
+
+    .monitoring-toolbar-toggle-button,
+    .monitoring-toolbar-add-button,
+    .monitoring-toolbar-see-button,
+    .monitoring-toolbar-delete-button {
+      margin-right: 8px;
+      margin-left: unset;
+    }
   }
 }

--- a/src/components/ResizableSection/ResizableSection.jsx
+++ b/src/components/ResizableSection/ResizableSection.jsx
@@ -1,76 +1,26 @@
 // REACT LIBS
-import PropTypes from 'prop-types';
 import React from 'react';
-
-// UI LIBS
 import { Tooltip } from 'antd';
+import PropTypes from 'prop-types';
 import ResizePanel from 'react-resize-panel';
 
-// COMPONENTS
 import { PopoverTip } from 'components';
 
-// STYLES
 import './ResizableSection.less';
 
-/**
- * Resizable section component that can be attached at right edge of the father.
- *
- * It should be given a placeholder, which can be any html element or component
- * to react. When there are no children the placeholder will be rendered.
- *
- * It can take any html element or react component as a child.
- *
- * It can receive a title and a tip.
- *
- * @param {object} props Component props
- * @returns {ResizableSection} Component
- * @component
- * @example
- * const htmlElement = <div id='htmlElement' />;
- * const placeholder = <div>This is Placeholder!</div>;
- * const title = 'This is title';
- * const tip = 'This is tip';
- *
- * return (
- *  <div style={{ backgroundColor: "#333", display: "flex", width: '100%', height: '300px'}}>
- *    <ResizableSection
- *      title={title}
- *      placeholder={placeholder}
- *      tip={tip}
- *    >
- *      {htmlElement}
- *    </ResizableSection>
- *  </div>
- * );
- */
 const ResizableSection = (props) => {
-  // destructuring props
   const { placeholder, title, tip, children } = props;
 
-  // resizable content
-  const content = (
-    /* section body */
-    <div className='resizable-section-body'>
-      {/* children (body) */}
-      {children}
-    </div>
-  );
-
-  // rendering component
   return (
-    // resizable area
     <ResizePanel
       direction='w'
-      style={{ minWidth: '18%' }}
+      style={{ width: '18%' }}
       handleClass='customHandle'
       borderClass='customResizeBorder'
     >
-      {/* section */}
       <div className='resizable-section'>
-        {/* section header */}
         {(title || tip) && (
           <div className='resizable-section-header'>
-            {/* title */}
             {title && (
               <div className='resizable-section-title'>
                 <h3>
@@ -83,9 +33,7 @@ const ResizableSection = (props) => {
               </div>
             )}
 
-            {/* tip */}
             {tip && (
-              // tip component
               <div className='resizable-section-tip'>
                 <PopoverTip
                   isPopoverBelow={true}
@@ -97,33 +45,28 @@ const ResizableSection = (props) => {
             )}
           </div>
         )}
-        {children ? content : placeholder}
+
+        {children ? (
+          <div className='resizable-section-body'>{children}</div>
+        ) : (
+          placeholder
+        )}
       </div>
     </ResizePanel>
   );
 };
 
-// PROP TYPES
 ResizableSection.propTypes = {
-  /** empty placeholder: elemento html ou componente react */
   placeholder: PropTypes.node.isRequired,
-  /** title: string */
   title: PropTypes.string,
-  /** tip: string */
   tip: PropTypes.string,
-  /** component children (body): elemento html ou componente react */
   children: PropTypes.node,
 };
 
-// DEFAULT PROPS
 ResizableSection.defaultProps = {
-  /** title: string */
   title: null,
-  /** tip: string */
   tip: null,
-  /** component children: elemento html ou componente react */
   children: null,
 };
 
-// EXPORT DEFAULT
 export default ResizableSection;

--- a/src/containers/MonitoringPanelContainer/MonitoringPanelContainer.jsx
+++ b/src/containers/MonitoringPanelContainer/MonitoringPanelContainer.jsx
@@ -7,14 +7,17 @@ import MonitoringToolbar from 'components/MonitoringToolbar';
 import { deleteMonitoring, fetchMonitorings } from 'store/monitorings/actions';
 import NewMonitoringModalContainer from 'containers/NewMonitoringModalContainer';
 
-import './styles.less';
+import useControlPanelVisibilities from './useControlPanelVisibilities';
+import useUnselectDeletedMonitoring from './useUnselectDeletedMonitoring';
 
-const monitoringsLoadingSelector = ({ uiReducer }) => {
-  return uiReducer.monitorings.loading;
-};
+import './styles.less';
 
 const monitoringsDeletingSelector = ({ uiReducer }) => {
   return uiReducer.monitorings.deleting;
+};
+
+const monitoringsLoadingSelector = ({ uiReducer }) => {
+  return uiReducer.monitorings.loading;
 };
 
 const monitoringsSelector = ({ monitoringsReducer }) => {
@@ -64,18 +67,16 @@ const MonitoringPanelContainer = () => {
     dispatch(fetchMonitorings(projectId, deploymentId));
   }, [deploymentId, dispatch, projectId]);
 
-  // Clear the selected monitoring when the monitorings list changes
-  useEffect(() => {
-    if (!selectedMonitoring) return;
+  useUnselectDeletedMonitoring({
+    monitorings,
+    selectedMonitoring,
+    setSelectedMonitoring,
+  });
 
-    const selectedMonitoringIndex = monitorings.findIndex((monitoring) => {
-      return monitoring.uuid === selectedMonitoring.uuid;
-    });
-
-    if (selectedMonitoringIndex === -1) {
-      setSelectedMonitoring(null);
-    }
-  }, [monitorings, selectedMonitoring]);
+  useControlPanelVisibilities({
+    isShowingPanel,
+    setIsShowingPanel,
+  });
 
   return (
     <div className='monitoring-panel-container'>

--- a/src/containers/MonitoringPanelContainer/useControlPanelVisibilities.js
+++ b/src/containers/MonitoringPanelContainer/useControlPanelVisibilities.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { hideLogsPanel } from 'store/ui/actions';
+
+const isShowingLogsPanelSelector = ({ uiReducer }) => {
+  return uiReducer.logsPanel.isShowing;
+};
+
+export default ({
+  isShowingPanel: isShowingMonitoringPanel,
+  setIsShowingPanel: setIsShowingMonitoringPanel,
+}) => {
+  const dispatch = useDispatch();
+
+  const isShowingLogsPanel = useSelector(isShowingLogsPanelSelector);
+
+  useEffect(() => {
+    if (isShowingLogsPanel) setIsShowingMonitoringPanel(false);
+  }, [isShowingLogsPanel, setIsShowingMonitoringPanel]);
+
+  useEffect(() => {
+    if (isShowingMonitoringPanel) dispatch(hideLogsPanel());
+  }, [dispatch, isShowingMonitoringPanel]);
+};

--- a/src/containers/MonitoringPanelContainer/useUnselectDeletedMonitoring.js
+++ b/src/containers/MonitoringPanelContainer/useUnselectDeletedMonitoring.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+export default ({ monitorings, selectedMonitoring, setSelectedMonitoring }) => {
+  useEffect(() => {
+    if (!selectedMonitoring) return;
+
+    const selectedMonitoringIndex = monitorings.findIndex((monitoring) => {
+      return monitoring.uuid === selectedMonitoring.uuid;
+    });
+
+    if (selectedMonitoringIndex === -1) setSelectedMonitoring(null);
+  }, [monitorings, selectedMonitoring, setSelectedMonitoring]);
+};


### PR DESCRIPTION
- Adjust monitoring panel toolbar for small screens or when reduces the window width
- Logs panel don't influences the PropertiesPanel width anymore
- Reduce the FlowDrop min height to allow the panels grow and prevent the page scroll to appear
- Create custom hook in MonitoringPanelContainer to show just one panel per time, so both monitorings panel and the logs panel cannot be shown at the same time 
- Improve MonitoringFlowBox component usability and code