### PR TITLE
Updates LogsDrawer to use new deployment logs API

### DIFF
--- a/src/components/DeploymentsTable/DeploymentsTable.component.jsx
+++ b/src/components/DeploymentsTable/DeploymentsTable.component.jsx
@@ -41,6 +41,7 @@ const DeploymentsTable = (props) => {
   const statusToBadge = {
     Failed: 'error',
     Running: 'processing',
+    Pending: 'processing',
     Succeeded: 'success',
   };
 
@@ -48,6 +49,7 @@ const DeploymentsTable = (props) => {
   const statusTextToPortuguese = {
     Failed: 'Falhou',
     Running: 'Em implantação',
+    Pending: 'Em implantação',
     Succeeded: 'Sucesso',
   };
 

--- a/src/components/DeploymentsTable/DeploymentsTable.component.jsx
+++ b/src/components/DeploymentsTable/DeploymentsTable.component.jsx
@@ -101,7 +101,11 @@ const DeploymentsTable = (props) => {
       render: (value, record) => (
         <>
           <UploadInferenceTestButton
-            disabled={record.status === 'Failed' || record.status === 'Running'}
+            disabled={
+              record.status === 'Failed' ||
+              record.status === 'Running' ||
+              record.status === 'Pending'
+            }
             handleUpload={(file) =>
               onTestInference(projectId, record.uuid, file)
             }

--- a/src/components/LogsDrawer/LogsDrawer.component.jsx
+++ b/src/components/LogsDrawer/LogsDrawer.component.jsx
@@ -18,16 +18,25 @@ const LogsDrawer = ({ handleClose, isLoading, isVisible, logs, title }) => {
   // EMPTY COMPONENT
   const renderEmpty = () => <span>Não há dados.</span>;
 
+  // Joins logs per title so we show one tab for each title
+  const logsPerTitle = {};
+  logs.forEach((element) => {
+    if (logsPerTitle[element.title] === undefined) {
+      logsPerTitle[element.title] = [];
+    }
+    logsPerTitle[element.title].push(element);
+  });
+
   // COLUMNS OF LOG TABLE
   const logsTableColumns = [
     {
       title: 'Data',
-      dataIndex: 'timestamp',
-      key: 'timestamp',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
       width: 175,
       render: (value) => {
         //The value of timestamp is missformated, so we need to split the string to get the right timestamp
-        if (value) return new Date(value.split(' ')[0]).toLocaleString()
+        if (value) return new Date(value.split(' ')[0]).toLocaleString();
         return '-';
       },
       //this is the arrow function to make header sorter of date column
@@ -78,17 +87,17 @@ const LogsDrawer = ({ handleClose, isLoading, isVisible, logs, title }) => {
           <div>
             <span style={{ fontSize: '12px' }}>CONTAINERS EM EXECUÇÃO: </span>
             <span style={{ color: '#262626', fontSize: '14px' }}>
-              {logs.length}
+              {Object.keys(logsPerTitle).length}
             </span>
           </div>
           <Tabs>
-            {logs.map((container, i) => (
-              <TabPane tab={container.containerName} key={i}>
+            {Object.entries(logsPerTitle).map(([title, logsList], i) => (
+              <TabPane tab={title} key={i}>
                 <ConfigProvider renderEmpty={renderEmpty}>
                   <CommonTable
                     bordered={true}
                     columns={logsTableColumns}
-                    dataSource={container.logs}
+                    dataSource={logsList}
                     isLoading={false}
                     pagination={{
                       defaultPageSize: 10,

--- a/src/components/LogsDrawer/LogsDrawer.component.jsx
+++ b/src/components/LogsDrawer/LogsDrawer.component.jsx
@@ -91,8 +91,8 @@ const LogsDrawer = ({ handleClose, isLoading, isVisible, logs, title }) => {
             </span>
           </div>
           <Tabs>
-            {Object.entries(logsPerTitle).map(([title, logsList], i) => (
-              <TabPane tab={title} key={i}>
+            {Object.entries(logsPerTitle).map(([logTitle, logsList], i) => (
+              <TabPane tab={logTitle} key={i}>
                 <ConfigProvider renderEmpty={renderEmpty}>
                   <CommonTable
                     bordered={true}

--- a/src/containers/LogsDrawerContainer/LogsDrawerContainer.jsx
+++ b/src/containers/LogsDrawerContainer/LogsDrawerContainer.jsx
@@ -1,6 +1,6 @@
 // CORE LIBS
 import React from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 // COMPONENTS
 import { LogsDrawer } from 'components';
@@ -8,41 +8,44 @@ import { LogsDrawer } from 'components';
 // ACTIONS
 import { hideInferenceLogsDrawer } from 'store/ui/actions';
 
-// DISPATCHS
-const mapDispatchToProps = (dispatch) => {
-  return {
-    handleHideDrawer: () => dispatch(hideInferenceLogsDrawer()),
-  };
+const logsSelector = ({ deploymentLogsReducer }) => {
+  return deploymentLogsReducer.logs || [];
 };
 
-// STATES
-const mapStateToProps = (state) => {
-  return {
-    drawer: state.uiReducer.inferenceLogsDrawer,
-    logs: state.deploymentLogsReducer.logs,
-  };
+const isLoadingSelector = ({ uiReducer }) => {
+  return uiReducer.inferenceLogsDrawer.loading;
 };
 
-/**
- * Container to display logs drawer.
- * @param {object} props Container props
- * @returns {LogsDrawerContainer} Container
- */
-const LogsDrawerContainer = (props) => {
-  const { drawer, handleHideDrawer, logs } = props;
+const isVisibleSelector = ({ uiReducer }) => {
+  return uiReducer.inferenceLogsDrawer.visible;
+};
+
+const titleSelector = ({ uiReducer }) => {
+  return uiReducer.inferenceLogsDrawer.title;
+};
+
+const LogsDrawerContainer = () => {
+  const dispatch = useDispatch();
+
+  const handleHideDrawer = () => {
+    dispatch(hideInferenceLogsDrawer());
+  };
+
+  const isLoading = useSelector(isLoadingSelector);
+  const isVisible = useSelector(isVisibleSelector);
+  const title = useSelector(titleSelector);
+  const logs = useSelector(logsSelector);
+
   return (
     <LogsDrawer
       handleClose={handleHideDrawer}
-      isLoading={drawer.loading}
-      isVisible={drawer.visible}
+      isLoading={isLoading}
+      isVisible={isVisible}
       logs={logs}
-      title={drawer.title}
+      title={title}
     />
   );
 };
 
 // EXPORT
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LogsDrawerContainer);
+export default LogsDrawerContainer;


### PR DESCRIPTION
New API does not return the logs split by container, so we have to
build the splits in frontend.