### PR TITLE
Feature - Use operator name

### DIFF
--- a/src/store/operators/actions.js
+++ b/src/store/operators/actions.js
@@ -7,7 +7,6 @@ import actionTypes from './actionTypes';
 // SERVICES
 import datasetsApi from 'services/DatasetsApi';
 import operatorsApi from 'services/OperatorsApi';
-import tasksApi from 'services/TasksApi';
 
 // UI ACTIONS
 import {
@@ -90,9 +89,6 @@ export const fetchOperatorsRequest =
     dispatch(resultsButtonBarLoadingData());
 
     try {
-      // getting tasks
-      const tasksResponse = await tasksApi.getAllTasks();
-      const tasks = tasksResponse.data.tasks;
       // getting operators
       const operatorsResponse = await operatorsApi.listOperators(
         projectId,
@@ -101,7 +97,7 @@ export const fetchOperatorsRequest =
       const operators = operatorsResponse.data.operators;
 
       // getting dataset columns
-      const datasetName = utils.getDatasetName(tasks, operators);
+      const datasetName = utils.getDatasetName(undefined, operators);
       let datasetColumns = [];
       if (datasetName) {
         const response = await datasetsApi.listDatasetColumns(datasetName);
@@ -110,7 +106,7 @@ export const fetchOperatorsRequest =
 
       // configuring operators
       let configuredOperators = utils.configureOperators(
-        tasks,
+        undefined,
         operators,
         datasetColumns
       );

--- a/src/store/operators/actions.js
+++ b/src/store/operators/actions.js
@@ -81,45 +81,44 @@ const fetchOperatorsFail = (error) => (dispatch) => {
  * @param {string} experimentId
  * @returns {Function}
  */
-export const fetchOperatorsRequest = (projectId, experimentId) => async (
-  dispatch
-) => {
-  dispatch({
-    type: actionTypes.FETCH_OPERATORS_REQUEST,
-  });
-  dispatch(experimentOperatorsLoadingData());
-  dispatch(resultsButtonBarLoadingData());
+export const fetchOperatorsRequest =
+  (projectId, experimentId) => async (dispatch) => {
+    dispatch({
+      type: actionTypes.FETCH_OPERATORS_REQUEST,
+    });
+    dispatch(experimentOperatorsLoadingData());
+    dispatch(resultsButtonBarLoadingData());
 
-  try {
-    // getting tasks
-    const tasksResponse = await tasksApi.getAllTasks();
-    const tasks = tasksResponse.data.tasks;
-    // getting operators
-    const operatorsResponse = await operatorsApi.listOperators(
-      projectId,
-      experimentId
-    );
-    const operators = operatorsResponse.data.operators;
+    try {
+      // getting tasks
+      const tasksResponse = await tasksApi.getAllTasks();
+      const tasks = tasksResponse.data.tasks;
+      // getting operators
+      const operatorsResponse = await operatorsApi.listOperators(
+        projectId,
+        experimentId
+      );
+      const operators = operatorsResponse.data.operators;
 
-    // getting dataset columns
-    const datasetName = utils.getDatasetName(tasks, operators);
-    let datasetColumns = [];
-    if (datasetName) {
-      const response = await datasetsApi.listDatasetColumns(datasetName);
-      datasetColumns = response.data;
+      // getting dataset columns
+      const datasetName = utils.getDatasetName(tasks, operators);
+      let datasetColumns = [];
+      if (datasetName) {
+        const response = await datasetsApi.listDatasetColumns(datasetName);
+        datasetColumns = response.data;
+      }
+
+      // configuring operators
+      let configuredOperators = utils.configureOperators(
+        tasks,
+        operators,
+        datasetColumns
+      );
+      dispatch(fetchOperatorsSuccess(configuredOperators));
+    } catch (e) {
+      dispatch(fetchOperatorsFail(e));
     }
-
-    // configuring operators
-    let configuredOperators = utils.configureOperators(
-      tasks,
-      operators,
-      datasetColumns
-    );
-    dispatch(fetchOperatorsSuccess(configuredOperators));
-  } catch (e) {
-    dispatch(fetchOperatorsFail(e));
-  }
-};
+  };
 
 /**
  * Clear operators feature parameters
@@ -128,91 +127,90 @@ export const fetchOperatorsRequest = (projectId, experimentId) => async (
  * @param {string} experimentId
  * @param dataset
  */
-export const clearOperatorsFeatureParametersRequest = (
-  projectId,
-  experimentId,
-  dataset
-) => async (dispatch, getState) => {
-  const { operatorsReducer: operators } = getState();
-
-  dispatch({
-    type: actionTypes.CLEAR_OPERATORS_FEATURE_PARAMETERS_REQUEST,
-  });
-
-  dispatch(operatorParameterLoadingData());
-
-  try {
-    // getting all operators with feature parameter
-    const operatorsWithFeatureParameter = [];
-    operators.forEach((operator) => {
-      const newOperator = { ...operator };
-
-      // getting operator feature parameters
-      const operatorFeatureParameters = operator.parameters.filter(
-        (parameter) => {
-          if (parameter.type === 'feature') {
-            return true;
-          }
-          return false;
-        }
-      );
-
-      // adding operator to list if it has feature parameters
-      if (operatorFeatureParameters.length > 0) {
-        operatorsWithFeatureParameter.push(newOperator);
-      }
-    });
-
-    // clear operators feature parameters
-    for (const operator of operatorsWithFeatureParameter) {
-      // creating parameter object to update without the feature parameter
-      const parameters = {};
-      operator.parameters.forEach(({ name, type, value }) => {
-        if (type !== 'feature') {
-          parameters[name] = value;
-        }
-      });
-      const body = { parameters };
-      await operatorsApi
-        .updateOperator(projectId, experimentId, operator.uuid, body)
-        .catch((error) => {
-          console.log(error);
-        });
-    }
+export const clearOperatorsFeatureParametersRequest =
+  (projectId, experimentId, dataset) => async (dispatch, getState) => {
+    const { operatorsReducer: operators } = getState();
 
     dispatch({
-      type: actionTypes.UPDATE_OPERATORS_OPTIONS,
-      columns: dataset ? dataset.columns : [],
+      type: actionTypes.CLEAR_OPERATORS_FEATURE_PARAMETERS_REQUEST,
     });
 
-    dispatch(operatorParameterDataLoaded());
-  } catch (e) {
-    dispatch(operatorParameterDataLoaded());
-    console.log(e);
-  }
-};
+    dispatch(operatorParameterLoadingData());
+
+    try {
+      // getting all operators with feature parameter
+      const operatorsWithFeatureParameter = [];
+      operators.forEach((operator) => {
+        const newOperator = { ...operator };
+
+        // getting operator feature parameters
+        const operatorFeatureParameters = operator.parameters.filter(
+          (parameter) => {
+            if (parameter.type === 'feature') {
+              return true;
+            }
+            return false;
+          }
+        );
+
+        // adding operator to list if it has feature parameters
+        if (operatorFeatureParameters.length > 0) {
+          operatorsWithFeatureParameter.push(newOperator);
+        }
+      });
+
+      // clear operators feature parameters
+      for (const operator of operatorsWithFeatureParameter) {
+        // creating parameter object to update without the feature parameter
+        const parameters = {};
+        operator.parameters.forEach(({ name, type, value }) => {
+          if (type !== 'feature') {
+            parameters[name] = value;
+          }
+        });
+        const body = { parameters };
+        await operatorsApi
+          .updateOperator(projectId, experimentId, operator.uuid, body)
+          .catch((error) => {
+            console.log(error);
+          });
+      }
+
+      dispatch({
+        type: actionTypes.UPDATE_OPERATORS_OPTIONS,
+        columns: dataset ? dataset.columns : [],
+      });
+
+      dispatch(operatorParameterDataLoaded());
+    } catch (e) {
+      dispatch(operatorParameterDataLoaded());
+      console.log(e);
+    }
+  };
 
 // // // // // // // // // //
 
-export const upadteOperatorDependencies = (operators) => async (
-  dispatch,
-  getState
-) => {
-  // getting store data
-  const { tasksReducer, datasetReducer } = getState();
+export const upadteOperatorDependencies =
+  (operators) => async (dispatch, getState) => {
+    // getting store data
+    const { tasksReducer, datasetReducer } = getState();
 
-  // getting tasks
-  const { tasks } = tasksReducer;
+    // getting tasks
+    const { tasks } = tasksReducer;
 
-  // getting dataset columns
-  const { columns } = datasetReducer;
+    // getting dataset columns
+    const { columns } = datasetReducer;
 
-  // configuring operators
-  let configuredOperators = utils.configureOperators(tasks, operators, columns);
+    // configuring operators
+    let configuredOperators = utils.configureOperators(
+      tasks,
+      operators,
+      columns
+    );
 
-  // create/dispatch action
-  dispatch({
-    type: actionTypes.UPDATE_OPERATOR_DEPENDENCIES,
-    operators: configuredOperators,
-  });
-};
+    // create/dispatch action
+    dispatch({
+      type: actionTypes.UPDATE_OPERATOR_DEPENDENCIES,
+      operators: configuredOperators,
+    });
+  };

--- a/src/utils.js
+++ b/src/utils.js
@@ -286,13 +286,14 @@ const getTagConfig = (tag) => {
  *
  * @param {object[]} tasks tasks list
  * @param {string} taskId task id
+ * @param {object=} task task object
  * @returns {object} task data
  */
-const getTaskData = (tasks, taskId) => {
+const getTaskData = (tasks, taskId, task = undefined) => {
   // params to filter constant
   const parametersToFilter = ['dataset'];
 
-  if (tasks.length > 0 && taskId) {
+  if (tasks && tasks.length > 0 && taskId) {
     // getting tasks data
     const taskData = tasks.find((task) => task.uuid === taskId);
     const {
@@ -330,6 +331,26 @@ const getTaskData = (tasks, taskId) => {
       deploymentNotebookPath,
       parameters: filteredParams,
       description,
+    };
+  }
+
+  if (task) {
+    const { name, tags, parameters } = task;
+
+    const { icon } = getTagConfig(tags[0]);
+
+    let filteredParams;
+    if (parameters) {
+      filteredParams = parameters.filter(
+        (parameter) => !parametersToFilter.includes(parameter.name)
+      );
+    }
+
+    return {
+      name,
+      icon,
+      tags,
+      parameters: filteredParams,
     };
   }
 
@@ -450,7 +471,7 @@ const configureOperators = (tasks, operators, datasetColumns) => {
       parameters: taskParameters,
       tags,
       ...restTaskData
-    } = getTaskData(tasks, operator.taskId);
+    } = getTaskData(tasks, operator.taskId, operator.task);
 
     // check if operator is dataset
     const isDataset = tags.includes('DATASETS');
@@ -545,23 +566,33 @@ const getErrorMessage = (error) => {
  * @returns {string} dataset name
  */
 const getDatasetName = (tasks, operators) => {
-  const datasetTasks = tasks
-    .filter((i) => {
-      return i.tags.includes('DATASETS');
-    })
-    .map((task) => task.uuid);
-  const datasetOperator = operators.find((i) => {
-    return datasetTasks.includes(i.taskId);
-  });
   let datasetName = undefined;
-  if (datasetOperator) {
-    const parameters = datasetOperator.parameters;
-    if (parameters instanceof Array) {
-      datasetName = parameters.find((i) => i.name === 'dataset')?.value;
-    } else {
-      datasetName = parameters.dataset;
+
+  if (tasks) {
+    const datasetTasks = tasks
+      .filter((i) => {
+        return i.tags.includes('DATASETS');
+      })
+      .map((task) => task.uuid);
+    const datasetOperator = operators.find((i) => {
+      return datasetTasks.includes(i.taskId);
+    });
+    if (datasetOperator) {
+      const parameters = datasetOperator.parameters;
+      if (parameters instanceof Array) {
+        datasetName = parameters.find((i) => i.name === 'dataset')?.value;
+      } else {
+        datasetName = parameters.dataset;
+      }
     }
+  } else {
+    operators.forEach((operator) => {
+      if (operator.task.tags.includes('DATASETS')) {
+        datasetName = operator.parameters.dataset;
+      }
+    });
   }
+
   return datasetName;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -295,7 +295,7 @@ const getTaskData = (tasks, taskId, task = undefined) => {
 
   if (tasks && tasks.length > 0 && taskId) {
     // getting tasks data
-    const taskData = tasks.find((task) => task.uuid === taskId);
+    const taskData = tasks.find((taskItem) => taskItem.uuid === taskId);
     const {
       name,
       tags,

--- a/src/utils.js
+++ b/src/utils.js
@@ -488,12 +488,11 @@ const configureOperators = (tasks, operators, datasetColumns) => {
     const settedUp = checkOperatorSettedUp(operator);
 
     return {
-      ...operator,
       ...restTaskData,
+      ...operator,
       parameters,
       settedUp,
       selected: false,
-      status: operator.status,
       tags,
     };
   });


### PR DESCRIPTION
Durante a tarefa percebi que o status de setted up não está funcionando, inclusive na master.

---

Os seguintes dados não retornam mais nos operadores:

```
{
...
  image,
  commands,
  args,
  experimentNotebookPath,
  deploymentNotebookPath,
  description,
...
}
```

---

O que foi realizado:

- Adjust file format
- Refactor utils to use operator data
- Remove fetch tasks
- Adjust utils to use operator name
