### PR TITLE
FIx - Destroy Experiment Notifications

### DIFF
--- a/src/pages/Experiments/Experiments.page.jsx
+++ b/src/pages/Experiments/Experiments.page.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Layout } from 'antd';
+import React, { useEffect } from 'react';
+import { Layout, notification } from 'antd';
 import { useParams } from 'react-router-dom';
 
 import CustomDndProvider from 'components/CustomDndProvider';
@@ -23,6 +23,13 @@ import './Experiments.style.less';
 
 const Experiments = () => {
   const { experimentId } = useParams();
+
+  useEffect(() => {
+    return () => {
+      // Destroy operator status notifications when leave experiment page
+      notification.destroy();
+    };
+  }, []);
 
   return (
     <CustomDndProvider>

--- a/src/pages/Experiments/ExperimentsTabs/ExperimentTabsContainer.js
+++ b/src/pages/Experiments/ExperimentsTabs/ExperimentTabsContainer.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { notification } from 'antd';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 
@@ -8,12 +9,12 @@ import {
   Actions as experimentsActions,
 } from 'store/projects/experiments';
 import { useIsLoading } from 'hooks';
+import { hideLogsPanel } from 'store/ui/actions';
 import { deselectOperator } from 'store/operator/actions';
 import { clearAllExperimentLogs } from 'store/experimentLogs/actions';
 import { Actions as projectsActions, PROJECTS_TYPES } from 'store/projects';
 
 import ExperimentsTabs from './index';
-import { hideLogsPanel } from 'store/ui/actions';
 
 const { getExperiments } = Selectors;
 
@@ -89,6 +90,9 @@ const ExperimentTabsContainer = () => {
       history.push(getCurrentRoutePath(projectId, targetId));
       dispatch(clearAllExperimentLogs());
       dispatch(deselectOperator());
+
+      // Destroy operator status notifications when change experiment
+      notification.destroy();
     }
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -757,16 +757,18 @@ const formatResultsParameters = (parameters, parametersTraining) => {
 };
 
 const retrieveStatusMessageFromOperators = (operators) => {
-  operators.map(
-    (operator) =>
-      operator.statusMessage &&
+  if (!operators) return;
+
+  operators.forEach((operator) => {
+    if (operator.statusMessage) {
       notification.open({
-        key: `${operator?.task?.name}_${operator.statusMessage}`,
+        key: `${operator.uuid}-${operator.statusMessage}`,
         duration: 0,
-        message: operator?.task?.name,
+        message: operator.task?.name,
         description: operator.statusMessage,
-      })
-  );
+      });
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
- Destroy operator status notifications when leave experiment page
- Destroy operator status notifications when change the selected experiment clicking in another tab