### PR TITLE
Fix - Deployment Page State Cleanup When Unmount

### DIFF
--- a/src/containers/DeploymentsTabsContainer/DeploymentsTabsContainer.jsx
+++ b/src/containers/DeploymentsTabsContainer/DeploymentsTabsContainer.jsx
@@ -137,6 +137,9 @@ const DeploymentsTabsContainer = () => {
   useEffect(() => {
     return () => {
       dispatch(clearAllDeployments());
+      dispatch(deselectOperator());
+      dispatch(clearAllMonitorings());
+      dispatch(clearAllDeploymentOperators());
     };
   }, [dispatch]);
 


### PR DESCRIPTION
**To Test The Bug**

1. Select a project that have at least one deployment
2. Enter the deployments page and wait for the operators to load
3. Go back to the projects list page
4. Select another project with no deployments
5. Enter the deployments page
6. You should see monitorings and operators from the other deployment

- This PR fixes this bug by cleaning up the state when the user leave the deployments page  