### PR TITLE
Fix - Previous Refactor Mistakes

### DIFF
--- a/src/components/Buttons/DebugButton/DebugButton.component.jsx
+++ b/src/components/Buttons/DebugButton/DebugButton.component.jsx
@@ -21,8 +21,8 @@ const DebugButton = ({ onClick, active, disabled }) => {
 
 DebugButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  active: PropTypes.boolean,
-  disabled: PropTypes.boolean,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 DebugButton.defaultProps = {

--- a/src/components/Buttons/ErrorButton/ErrorButton.component.jsx
+++ b/src/components/Buttons/ErrorButton/ErrorButton.component.jsx
@@ -21,8 +21,8 @@ const ErrorButton = ({ onClick, disabled, active }) => {
 
 ErrorButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  active: PropTypes.boolean,
-  disabled: PropTypes.boolean,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 ErrorButton.defaultProps = {

--- a/src/components/Buttons/InfoButton/InfoButton.component.jsx
+++ b/src/components/Buttons/InfoButton/InfoButton.component.jsx
@@ -21,8 +21,8 @@ const InfoButton = ({ onClick, disabled, active }) => {
 
 InfoButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  active: PropTypes.boolean,
-  disabled: PropTypes.boolean,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 InfoButton.defaultProps = {

--- a/src/containers/UsingDeploymentsModalContainer/UsingDeploymentsModalContainer.jsx
+++ b/src/containers/UsingDeploymentsModalContainer/UsingDeploymentsModalContainer.jsx
@@ -60,15 +60,11 @@ const ContentInfo = () => {
       <pre style={styles}>{request}</pre>
       <p></p>
       <p>
-        <b>
-          <q>names</q>:[...]
-        </b>
+        <b>&quot;names&quot;:[...]</b>
         - nome das colunas do conjunto de dados, sem o nome do atributo alvo.
         <br />
-        <b>
-          <q>ndarray</q>:[...]
-        </b>
-        - amostras para predição, sem o valor atributo alvo.
+        <b>&quot;ndarray&quot;:[...]</b>- amostras para predição, sem o valor
+        atributo alvo.
       </p>
 
       <h3>Response Body:</h3>
@@ -76,16 +72,12 @@ const ContentInfo = () => {
       <pre style={styles}>{response}</pre>
 
       <p>
-        <b>
-          <q>names</q>:[...]
-        </b>
+        <b>&quot;names&quot;:[...]</b>
         - nome das colunas retornadas pelo último passo do fluxo de
         experimentos.
         <br />
-        <b>
-          <q>ndarray</q>:[...]
-        </b>
-        - valores retornados pelo último passo do fluxo de experimentos.
+        <b>&quot;ndarray&quot;:[...]</b>- valores retornados pelo último passo
+        do fluxo de experimentos.
       </p>
     </div>
   );

--- a/src/pages/Experiments/Experiment/Drawer/ResultsDrawer/MetricsTitle/index.js
+++ b/src/pages/Experiments/Experiment/Drawer/ResultsDrawer/MetricsTitle/index.js
@@ -13,7 +13,7 @@ const MetricsTitle = ({ loading }) => {
 };
 
 MetricsTitle.propTypes = {
-  loading: PropTypes.boolean,
+  loading: PropTypes.bool,
 };
 
 MetricsTitle.defaultProps = {


### PR DESCRIPTION
- Fix boolean prop types that were incorrectly
- Use `&quot;` instead of the `<q>` element to show double quotes

Thank you @cedric-matheus for appointing these mistakes here -> https://github.com/platiagro/web-ui/pull/426 