### PR TITLE
Fix - Log Item Message Line Break

### DIFF
--- a/src/components/LogListItem/styles.less
+++ b/src/components/LogListItem/styles.less
@@ -15,6 +15,8 @@
 
     .log-list-item-content-text {
       word-break: break-word;
+      white-space: pre-wrap;
+      font-family: monospace;
     }
   }
 


### PR DESCRIPTION
- Add `font-family: monospace` in the log item message
- Add `white-space: pre-wrap` in the log item message