### PR TITLE
Fix - Error 404 Redirection

### DIFF
--- a/src/pages/Deployment/Deployment.page.jsx
+++ b/src/pages/Deployment/Deployment.page.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router';
 import { ReactFlowProvider } from 'react-flow-renderer';
 
 import {
@@ -11,9 +12,15 @@ import {
   PropertiesResizableContainer,
 } from 'containers';
 
+import useRedirectToError404 from './useRedirectToError404';
+
 import './Deployment.style.less';
 
 const Deployment = () => {
+  const { deploymentId } = useParams();
+
+  useRedirectToError404(deploymentId);
+
   return (
     <ReactFlowProvider>
       <div className='deployment-page'>

--- a/src/pages/Deployment/useRedirectToError404.js
+++ b/src/pages/Deployment/useRedirectToError404.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
+
+const deploymentsSelector = ({ deploymentsReducer }) => {
+  return deploymentsReducer;
+};
+
+export default (deploymentId) => {
+  const history = useHistory();
+
+  const deployments = useSelector(deploymentsSelector);
+
+  useEffect(() => {
+    if (!deployments?.length || !deploymentId) return;
+
+    const currentExperiment = deployments.find(
+      ({ uuid }) => uuid === deploymentId
+    );
+
+    if (!currentExperiment) {
+      history.replace('/erro-404');
+    }
+  }, [deploymentId, deployments, history]);
+};

--- a/src/pages/Experiments/Experiments.page.jsx
+++ b/src/pages/Experiments/Experiments.page.jsx
@@ -18,14 +18,16 @@ import NewExperimentButton from './NewExperimentButton/NewExperimentButtonContai
 import NewExperimentModal from './NewExperimentModal/NewExperimentModalContainer';
 import ExperimentsTabs from './ExperimentsTabs/ExperimentTabsContainer';
 import TasksMenuBlock from './TasksMenuBlock/TasksMenuBlockContainer';
+import useRedirectToError404 from './useRedirectToError404';
 import FlowDrop from './FlowDrop';
 
 import './Experiments.style.less';
 
 const Experiments = () => {
-  const { experimentId } = useParams();
+  const { projectId, experimentId } = useParams();
 
   useShowOperatorStatusNotifications();
+  useRedirectToError404(projectId, experimentId);
 
   useEffect(() => {
     return () => {

--- a/src/pages/Experiments/ExperimentsTabs/ExperimentTabsContainer.js
+++ b/src/pages/Experiments/ExperimentsTabs/ExperimentTabsContainer.js
@@ -111,8 +111,8 @@ const ExperimentTabsContainer = () => {
   };
 
   useEffect(() => {
-    dispatch(projectsActions.fetchProjectRequest(projectId));
-  }, [projectId, dispatch]);
+    dispatch(projectsActions.fetchProjectRequest(projectId, history));
+  }, [projectId, dispatch, history]);
 
   // Redirect to the active experiment or to the first experiment
   // if the user deletes the active experiment

--- a/src/pages/Experiments/useRedirectToError404.js
+++ b/src/pages/Experiments/useRedirectToError404.js
@@ -14,7 +14,7 @@ export default (projectId, experimentId) => {
   const experiments = useSelector(experimentsSelector(projectId));
 
   useEffect(() => {
-    if (!experiments?.length || !projectId || !experimentId) return;
+    if (!experiments?.length || !experimentId) return;
 
     const currentExperiment = experiments.find(
       ({ uuid }) => uuid === experimentId
@@ -23,5 +23,5 @@ export default (projectId, experimentId) => {
     if (!currentExperiment) {
       history.replace('/erro-404');
     }
-  }, [experimentId, experiments, history, projectId]);
+  }, [experimentId, experiments, history]);
 };

--- a/src/pages/Experiments/useRedirectToError404.js
+++ b/src/pages/Experiments/useRedirectToError404.js
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
+
+import { Selectors } from 'store/projects/experiments';
+
+const experimentsSelector = (projectId) => (state) => {
+  return Selectors.getExperiments(state, projectId);
+};
+
+export default (projectId, experimentId) => {
+  const history = useHistory();
+
+  const experiments = useSelector(experimentsSelector(projectId));
+
+  useEffect(() => {
+    if (!experiments?.length || !projectId || !experimentId) return;
+
+    const currentExperiment = experiments.find(
+      ({ uuid }) => uuid === experimentId
+    );
+
+    if (!currentExperiment) {
+      history.replace('/erro-404');
+    }
+  }, [experimentId, experiments, history, projectId]);
+};

--- a/src/store/projects/experiments/experiments.selectors.js
+++ b/src/store/projects/experiments/experiments.selectors.js
@@ -29,8 +29,7 @@ const getExperiments = (state, projectId) => {
 const getExperiment = (state, projectId, experimentId) => {
   const experiments = getExperiments(state, projectId);
 
-  let isSucceeded = false;
-  let experiment = {
+  const defaultExperiment = {
     uuid: '',
     name: '',
     position: 0,
@@ -39,20 +38,22 @@ const getExperiment = (state, projectId, experimentId) => {
     operators: [],
     createdAt: '',
     updatedAt: '',
-    succeeded: isSucceeded,
+    succeeded: false,
   };
 
-  if (experiments?.length > 0 && experimentId)
-    experiment = experiments.find(
-      (experimentItem) => experimentItem.uuid === experimentId
-    );
+  if (experiments?.length > 0 && experimentId) {
+    const experiment = experiments.find(({ uuid }) => uuid === experimentId);
+    if (!experiment) return defaultExperiment;
 
-  if (experiment.operators.length > 0)
-    isSucceeded = utils.checkExperimentSuccess(experiment);
+    experiment.isSucceeded = false;
+    if (experiment?.operators?.length > 0) {
+      experiment.isSucceeded = utils.checkExperimentSuccess(experiment);
+    }
 
-  experiment.succeeded = isSucceeded;
+    return experiment;
+  }
 
-  return experiment;
+  return defaultExperiment;
 };
 
 export { getExperiments, getExperiment };


### PR DESCRIPTION
- Create a custom hook called `useRedirectToError404` in the `experiment` page. This hook get the `experiment array` and check if the UUID from route params exists in the array. If doesn't exist, the user will be redirected to the Error 404 page.
- Create a custom hook called `useRedirectToError404` in the `deployment` page. This hook get the `deployment array` and check if the UUID from route params exists in the array. If doesn't exist, the user will be redirected to the Error 404 page.
- Pass history to fetchProjectRequest to be able to redirect the user to Error 404 page if the project doesn't exist

This is one of the possible solutions. I don't think that it is the best but solves the problem. Another solution would be pass the deployment and experiment UUID to the `fetchProjectRequest` only to check if these UUIDs exist in the correct array, but I don't think that it would be a good idea.