### PR TITLE
Fix - Task Creation With Category

### DIFF
--- a/src/services/TasksApi.js
+++ b/src/services/TasksApi.js
@@ -15,6 +15,7 @@ const createTask = (task) => {
     copy_from: task.template === 'uuid' ? '' : task.template,
     name: task.name,
     description: task.description,
+    category: 'DEFAULT',
   };
   return taskApi.post('/tasks', body);
 };


### PR DESCRIPTION
Problem: the new task API broke the task creation in the website
Temporary solution: send a category when creating a new task

When the new task pages come out, the temporary solution will be removed.