### PR TITLE
Allow error 404 to not show popup

### DIFF
--- a/src/store/compareResults/actions.js
+++ b/src/store/compareResults/actions.js
@@ -197,7 +197,10 @@ export const fetchCompareResultsResults =
         compareResult: compareResultsAux,
       });
     } catch (e) {
-      dispatch(showError(e.message));
+      const code = e?.response?.status;
+      if (code !== 404) {
+        dispatch(showError(e.message));
+      }
     }
   };
 


### PR DESCRIPTION
Just leave error 404 from dataset and figures pass silent on compare results