### PR TITLE
Fix - Observations Tab Inside Data Visualization Modal

### DIFF
--- a/src/store/dataset/datasetReducer.js
+++ b/src/store/dataset/datasetReducer.js
@@ -10,6 +10,8 @@ const initialState = {
   cancelToken: null,
   columns: [],
   featuretypes: '',
+  pageSize: 0,
+  total: 0,
 };
 
 /**


### PR DESCRIPTION
- Add default value for `total` and `pageSize` in the dataset reducer because the antd `<Pagination />` component crashes if the pageSize number is undefined 