### PR TITLE
Feature - Deployment Page Logs Polling Request

### DIFF
--- a/src/store/deploymentLogs/actions.js
+++ b/src/store/deploymentLogs/actions.js
@@ -15,14 +15,20 @@ import { showError } from 'store/message';
  * @param {string} projectId Project ID
  * @param {string} deployId Deployment ID
  * @param {boolean} shouldShowLogsDrawer Should open the logs drawer?
+ * @param {boolean} shouldShowLoading Should show the loading?
  * @returns {Function} Dispatch function
  */
 export const getDeployExperimentLogs =
-  (projectId, deployId, shouldShowLogsDrawer = true) =>
+  (
+    projectId,
+    deployId,
+    shouldShowLogsDrawer = true,
+    shouldShowLoading = true
+  ) =>
   async (dispatch) => {
     try {
       if (shouldShowLogsDrawer) dispatch(showInferenceLogsDrawer('Logs'));
-      dispatch(inferenceLogsDrawerLoadingData());
+      if (shouldShowLoading) dispatch(inferenceLogsDrawerLoadingData());
 
       const response = await deploymentsApi.fetchDeploymentRunLogs(
         projectId,


### PR DESCRIPTION
**Temporary solution until the deployments page implements the operators polling request**

- Create the logs polling request that don't show the loading state