### PR TITLE
Fix - Deployment Test Result File Name

### DIFF
--- a/src/components/Modals/DeploymentTestResultModal/DeploymentTestResultModalContent.jsx
+++ b/src/components/Modals/DeploymentTestResultModal/DeploymentTestResultModalContent.jsx
@@ -79,7 +79,14 @@ const DeploymentTestResultModalContent = ({
           Copiar
         </Button>
 
-        <a href={utils.downloadFile(testResult)} download='predict-file'>
+        <a
+          href={utils.downloadFile(testResult)}
+          download={
+            utils.getSeldonObjectMimeType(testResult) === 'data:text/csv'
+              ? 'predict-file.csv'
+              : 'predict-file'
+          }
+        >
           <Button
             type='primary'
             icon={<DownloadOutlined />}

--- a/src/components/Modals/DeploymentTestResultModal/DeploymentTestResultModalContent.jsx
+++ b/src/components/Modals/DeploymentTestResultModal/DeploymentTestResultModalContent.jsx
@@ -15,7 +15,7 @@ const DeploymentTestResultModalContent = ({
   handleTryAgain,
 }) => {
   const dataSource = useMemo(() => {
-    if (!testResult) return [];
+    if (!testResult?.ndarray || !testResult?.names) return [];
 
     return testResult.ndarray.map((e, i) => {
       const data = { key: i };
@@ -29,7 +29,7 @@ const DeploymentTestResultModalContent = ({
   }, [testResult]);
 
   const columns = useMemo(() => {
-    if (!testResult) return [];
+    if (!testResult?.names) return [];
 
     return testResult.names.map((name) => ({
       title: name,

--- a/src/utils/Generic.utils.js
+++ b/src/utils/Generic.utils.js
@@ -58,6 +58,8 @@ export const isImage = (seldonObject) => {
 
 /**
  * Get the mime type for a given seldon object
+ * For more mime types:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
  *
  * @param {object} seldonObject seldon object
  * @returns {string} mime type
@@ -136,6 +138,7 @@ export const downloadFile = (seldonObject) => {
   if (isBinaryDataSupported) return formatBase64(seldonObject);
   const base64 = btoa(toRawText(seldonObject));
   const mimeType = getSeldonObjectMimeType(seldonObject);
+  console.log(mimeType);
   return `${mimeType};base64,${base64}`;
 };
 

--- a/src/utils/Generic.utils.js
+++ b/src/utils/Generic.utils.js
@@ -62,13 +62,18 @@ export const isImage = (seldonObject) => {
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
  *
  * @param {object} seldonObject seldon object
+ * @param {object} contentType response content type
  * @returns {string} mime type
  */
-export const getSeldonObjectMimeType = (seldonObject) => {
+export const getSeldonObjectMimeType = (seldonObject, contentType) => {
   const { binData, names, ndarray, strData } = seldonObject;
   if (names && ndarray) return 'data:text/csv';
-  else if (binData) return 'data:image/jpeg';
   else if (strData) return 'data:text/plain';
+  else if (binData) {
+    if (contentType?.includes('png')) return 'data:image/png';
+    else if (contentType?.includes('video')) return 'data:video/mp4';
+    return 'data:image/jpeg';
+  }
   return '';
 };
 
@@ -79,7 +84,8 @@ export const getSeldonObjectMimeType = (seldonObject) => {
  * @returns {string} a string with in base64 format
  */
 export const formatBase64 = (seldonObject) => {
-  const mimeType = getSeldonObjectMimeType(seldonObject);
+  const contentType = seldonObject?.meta?.tags?.['content-type'];
+  const mimeType = getSeldonObjectMimeType(seldonObject, contentType);
   return `${mimeType};base64,${seldonObject.binData}`;
 };
 
@@ -138,7 +144,6 @@ export const downloadFile = (seldonObject) => {
   if (isBinaryDataSupported) return formatBase64(seldonObject);
   const base64 = btoa(toRawText(seldonObject));
   const mimeType = getSeldonObjectMimeType(seldonObject);
-  console.log(mimeType);
   return `${mimeType};base64,${base64}`;
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -26,6 +26,7 @@ import {
   readFileContent,
   sleep,
   toRawText,
+  getSeldonObjectMimeType,
 } from './Generic.utils';
 
 import {
@@ -70,6 +71,7 @@ export default {
   readFileContent,
   sleep,
   toRawText,
+  getSeldonObjectMimeType,
 
   formatCompareResultDate,
   formatResultsParameters,


### PR DESCRIPTION
- If the result is a CSV the downloaded file will be predic-file.csv
- If is an image it will be predic-file.jpg or predic-file.png
- If is a video it will be predic-file.mp4
- If is only text it will be predic-file.txt

**Due to time limitations the code was not refactored, but is highly recommended in another pull request to reduce complexity**