### PR TITLE
Fix - Fetch Experiment Run Status When Open Experiment Page

### DIFF
--- a/src/pages/Experiments/Experiment/ExperimentFlow/ExperimentFlowContainer.js
+++ b/src/pages/Experiments/Experiment/ExperimentFlow/ExperimentFlowContainer.js
@@ -82,12 +82,14 @@ const ExperimentFlowContainer = () => {
   };
 
   useEffect(() => {
+    dispatch(fetchExperimentRunStatusRequest(projectId, experimentId));
+
     const polling = setInterval(() => {
       dispatch(fetchExperimentRunStatusRequest(projectId, experimentId));
     }, 5000);
 
     return () => clearInterval(polling);
-  });
+  }, [dispatch, experimentId, projectId]);
 
   return (
     <ExperimentFlow


### PR DESCRIPTION
- Fetch experiment run status when experiment flow container renders so the execute/interrupt button update faster