### PR TITLE
Feature - Download Experiment Run Results

### DIFF
--- a/src/components/CompareResultItem/CompareResultItem.component.jsx
+++ b/src/components/CompareResultItem/CompareResultItem.component.jsx
@@ -18,6 +18,7 @@ const CompareResultItem = ({
   onDelete,
   onUpdate,
   onFetchResults,
+  handleDownloadResult,
   onLoadTrainingHistory,
   onResultDatasetPageChange,
 }) => {
@@ -66,6 +67,7 @@ const CompareResultItem = ({
           compareResult={compareResult}
           trainingDetail={trainingDetail}
           experimentsOptions={experimentsOptions}
+          handleDownloadResult={handleDownloadResult}
           onLoadTrainingHistory={onLoadTrainingHistory}
         />
       }
@@ -98,6 +100,7 @@ CompareResultItem.propTypes = {
   onDelete: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired,
   onFetchResults: PropTypes.func.isRequired,
+  handleDownloadResult: PropTypes.func.isRequired,
   onLoadTrainingHistory: PropTypes.func.isRequired,
   onResultDatasetPageChange: PropTypes.func.isRequired,
 };

--- a/src/components/CompareResultItem/CompareResultItemTitle.jsx
+++ b/src/components/CompareResultItem/CompareResultItemTitle.jsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Cascader, Popover, Space } from 'antd';
+import { Button, Cascader, Dropdown, Menu, Space } from 'antd';
 import {
   MoreOutlined,
   DeleteOutlined,
+  DownloadOutlined,
   ClockCircleTwoTone,
 } from '@ant-design/icons';
 
@@ -18,6 +19,7 @@ const CompareResultItemTitle = ({
   compareResult,
   trainingDetail,
   experimentsOptions,
+  handleDownloadResult,
   onLoadTrainingHistory,
 }) => {
   const defaultValue = useMemo(() => {
@@ -25,6 +27,11 @@ const CompareResultItemTitle = ({
       ? [compareResult.experimentId, compareResult.runId]
       : null;
   }, [compareResult.experimentId, compareResult.runId]);
+
+  const canDownloadResult =
+    !!compareResult.experimentId &&
+    !!compareResult.runId &&
+    !!compareResult.operatorId;
 
   const handleChangeValue = (value) => {
     const updatedCompareResult = {
@@ -75,18 +82,36 @@ const CompareResultItemTitle = ({
         )}
       </Space>
 
-      <Popover
-        placement='bottom'
-        content={
-          <Button
-            type='text'
-            icon={<DeleteOutlined />}
-            onClick={() => {
-              onDelete(compareResult.uuid);
-            }}
-          >
-            Remover
-          </Button>
+      <Dropdown
+        trigger={['click']}
+        overlay={
+          <Menu>
+            <Menu.Item
+              key='remove'
+              icon={<DeleteOutlined />}
+              onClick={() => {
+                onDelete(compareResult.uuid);
+              }}
+            >
+              <span>Remover</span>
+            </Menu.Item>
+
+            {canDownloadResult && (
+              <Menu.Item
+                key='download'
+                icon={<DownloadOutlined />}
+                onClick={() => {
+                  handleDownloadResult(
+                    compareResult.experimentId,
+                    compareResult.runId,
+                    compareResult.operatorId
+                  );
+                }}
+              >
+                <span>Fazer Download</span>
+              </Menu.Item>
+            )}
+          </Menu>
         }
       >
         <Button
@@ -94,7 +119,7 @@ const CompareResultItemTitle = ({
           icon={<MoreOutlined />}
           style={{ float: 'right' }}
         />
-      </Popover>
+      </Dropdown>
     </>
   );
 };
@@ -105,6 +130,7 @@ CompareResultItemTitle.propTypes = {
   compareResult: PropTypes.object.isRequired,
   trainingDetail: PropTypes.object.isRequired,
   onLoadTrainingHistory: PropTypes.func.isRequired,
+  handleDownloadResult: PropTypes.func.isRequired,
   experimentsOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/src/containers/CompareResultsModalContainer/CompareResultsModalContainer.jsx
+++ b/src/containers/CompareResultsModalContainer/CompareResultsModalContainer.jsx
@@ -2,15 +2,12 @@ import React, { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import RGL, { WidthProvider } from 'react-grid-layout';
 import { useSelector, useDispatch } from 'react-redux';
-import { Button, Card, Col, Divider, Row, Space } from 'antd';
+import { Button, Card, Col, Divider, Row, Space, Tooltip } from 'antd';
 import {
   PlusOutlined,
   LoadingOutlined,
   DownloadOutlined,
 } from '@ant-design/icons';
-
-import { Modal, Skeleton } from 'uiComponents';
-import { CommonTable, CompareResultItem } from 'components';
 
 import {
   addCompareResult,
@@ -21,6 +18,9 @@ import {
   fetchCompareResultsResults,
   getCompareResultDatasetPaginated,
 } from 'store/compareResults/actions';
+import utils from 'utils';
+import { Modal, Skeleton } from 'uiComponents';
+import { CommonTable, CompareResultItem } from 'components';
 import { changeVisibilityCompareResultsModal } from 'store/ui/actions';
 import { getExperiments } from 'store/projects/experiments/experiments.selectors';
 
@@ -87,6 +87,19 @@ const CompareResultsModalContainer = () => {
     return isLoading || deleteIsLoading;
   }, [deleteIsLoading, isLoading]);
 
+  const handleDownloadResults = () => {
+    compareResults?.forEach(({ experimentId, runId, operatorId }) => {
+      if (experimentId && runId && operatorId) {
+        utils.downloadExperimentRunResult({
+          projectId,
+          experimentId,
+          runId,
+          operatorId,
+        });
+      }
+    });
+  };
+
   useEffect(() => {
     if (isVisible) {
       dispatch(fetchCompareResults(projectId));
@@ -101,10 +114,16 @@ const CompareResultsModalContainer = () => {
 
       <Divider type='vertical' />
 
-      <Button shape='round' type='primary-inverse' disabled>
-        <DownloadOutlined />
-        Fazer download
-      </Button>
+      <Tooltip placement='bottom' title='Faz download dos resultados exibidos'>
+        <Button
+          shape='round'
+          type='primary-inverse'
+          onClick={handleDownloadResults}
+        >
+          <DownloadOutlined />
+          Fazer download
+        </Button>
+      </Tooltip>
     </Space>
   );
 
@@ -154,6 +173,14 @@ const CompareResultsModalContainer = () => {
               dispatch(
                 getCompareResultDatasetPaginated(results, page, pageSize)
               );
+            }}
+            handleDownloadResult={(experimentId, runId, operatorId) => {
+              utils.downloadExperimentRunResult({
+                projectId,
+                experimentId,
+                runId,
+                operatorId,
+              });
             }}
             onLoadTrainingHistory={(experimentId) => {
               dispatch(fetchTrainingHistory(projectId, experimentId));

--- a/src/containers/OperatorResultsModalContainer/OperatorResultsModalContainer.jsx
+++ b/src/containers/OperatorResultsModalContainer/OperatorResultsModalContainer.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
+import utils from 'utils';
 import { Modal } from 'uiComponents';
 import { hideOperatorResults } from 'store/ui/actions';
 import { getOperatorResultDataset } from 'store/operator';
@@ -96,6 +97,15 @@ const OperatorResultsModalContainer = () => {
     );
   };
 
+  const handleDownloadResult = () => {
+    utils.downloadExperimentRunResult({
+      projectId,
+      experimentId,
+      runId: 'latest',
+      operatorId,
+    });
+  };
+
   return (
     <Modal
       isFullScreen={true}
@@ -108,12 +118,11 @@ const OperatorResultsModalContainer = () => {
         dataset={operatorDataset}
         figures={operatorFigures}
         parameters={resultsParameters}
-        isToShowDownloadButtons={true}
         loading={operatorResultsLoading}
+        datasetScroll={{ x: datasetScrollX }}
+        handleDownloadResult={handleDownloadResult}
         onDatasetPageChange={handleOnDatasetPageChange}
-        datasetScroll={{
-          x: datasetScrollX,
-        }}
+        isToShowDownloadButtons
       />
     </Modal>
   );

--- a/src/pages/Experiments/Experiment/Drawer/ResultsDrawer/ResultsDrawer.less
+++ b/src/pages/Experiments/Experiment/Drawer/ResultsDrawer/ResultsDrawer.less
@@ -10,4 +10,8 @@
     margin-left: 0;
     margin-right: 0;
   }
+
+  .download-result-button {
+    margin-bottom: 8px;
+  }
 }

--- a/src/pages/Experiments/Experiment/Drawer/ResultsDrawer/index.js
+++ b/src/pages/Experiments/Experiment/Drawer/ResultsDrawer/index.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Empty, Spin, Tabs } from 'antd';
-import { LoadingOutlined } from '@ant-design/icons';
+import { LoadingOutlined, DownloadOutlined } from '@ant-design/icons';
 
 import { CommonTable } from 'components';
 import { DownloadOperatorDatasetContainer } from 'containers';
@@ -10,6 +10,7 @@ import PlotResult from './PlotResult';
 import TableResult from './TableResult';
 
 import './ResultsDrawer.less';
+import Button from 'antd/es/button';
 
 const parametersColumns = [
   {
@@ -30,21 +31,20 @@ const parametersColumns = [
   },
 ];
 
-const ResultsDrawer = (props) => {
-  const {
-    activeKey,
-    dataset,
-    datasetScroll,
-    figures,
-    isToShowDownloadButtons,
-    loading,
-    onDatasetPageChange,
-    onTabChange,
-    parameters,
-    resultsTabStyle,
-    scroll,
-  } = props;
-
+const ResultsDrawer = ({
+  activeKey,
+  dataset,
+  datasetScroll,
+  figures,
+  isToShowDownloadButtons,
+  loading,
+  onDatasetPageChange,
+  onTabChange,
+  parameters,
+  resultsTabStyle,
+  scroll,
+  handleDownloadResult,
+}) => {
   const hasResult = useMemo(() => {
     return figures.length > 0 || parameters.length > 0 || dataset;
   }, [dataset, figures.length, parameters.length]);
@@ -57,65 +57,79 @@ const ResultsDrawer = (props) => {
     );
   }
 
-  return (
-    <div className='resultsDrawer'>
-      {hasResult ? (
-        <Tabs defaultActiveKey={activeKey} onChange={onTabChange}>
-          {figures.map((result, i) => {
-            const index = i + 1;
-            return (
-              <Tabs.TabPane tab={`Figura ${index}`} key={index}>
-                <div style={resultsTabStyle}>
-                  <div className='tab-content'>
-                    <PlotResult key={result.uuid} plotUrl={result.plotUrl} />
-                  </div>
-                </div>
-              </Tabs.TabPane>
-            );
-          })}
-
-          <Tabs.TabPane
-            disabled={!dataset}
-            key={figures.length + 1}
-            tab={<span>Dataset</span>}
-          >
-            {!!dataset && (
-              <TableResult
-                key={dataset.uuid}
-                rows={dataset.rows}
-                total={dataset.total}
-                scroll={datasetScroll}
-                columns={dataset.columns}
-                pageSize={dataset.pageSize}
-                currentPage={dataset.currentPage}
-                onPageChange={onDatasetPageChange}
-              />
-            )}
-
-            {isToShowDownloadButtons && <DownloadOperatorDatasetContainer />}
-          </Tabs.TabPane>
-
-          <Tabs.TabPane
-            key={figures.length + 3}
-            tab={<span>Parâmetros</span>}
-            disabled={parameters.length <= 0}
-          >
-            <CommonTable
-              scroll={scroll}
-              isLoading={false}
-              dataSource={parameters}
-              columns={parametersColumns}
-              rowKey={(data, index) => data.name || `result-${index}`}
-              bordered
-            />
-          </Tabs.TabPane>
-        </Tabs>
-      ) : (
+  if (!hasResult) {
+    return (
+      <div className='resultsDrawer'>
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description='Não existem resultados!'
         />
+      </div>
+    );
+  }
+
+  return (
+    <div className='resultsDrawer'>
+      {isToShowDownloadButtons && (
+        <Button
+          className='download-result-button'
+          onClick={handleDownloadResult}
+          type='default'
+        >
+          <DownloadOutlined />
+          <span>Fazer download do resultado</span>
+        </Button>
       )}
+
+      <Tabs defaultActiveKey={activeKey} onChange={onTabChange}>
+        {figures.map((result, index) => {
+          return (
+            <Tabs.TabPane tab={`Figura ${index + 1}`} key={index}>
+              <div style={resultsTabStyle}>
+                <div className='tab-content'>
+                  <PlotResult key={result.uuid} plotUrl={result.plotUrl} />
+                </div>
+              </div>
+            </Tabs.TabPane>
+          );
+        })}
+
+        <Tabs.TabPane
+          disabled={!dataset}
+          key={figures.length + 1}
+          tab={<span>Dataset</span>}
+        >
+          {!!dataset && (
+            <TableResult
+              key={dataset.uuid}
+              rows={dataset.rows}
+              total={dataset.total}
+              scroll={datasetScroll}
+              columns={dataset.columns}
+              pageSize={dataset.pageSize}
+              currentPage={dataset.currentPage}
+              onPageChange={onDatasetPageChange}
+            />
+          )}
+
+          {isToShowDownloadButtons && <DownloadOperatorDatasetContainer />}
+        </Tabs.TabPane>
+
+        <Tabs.TabPane
+          key={figures.length + 3}
+          tab={<span>Parâmetros</span>}
+          disabled={parameters.length <= 0}
+        >
+          <CommonTable
+            scroll={scroll}
+            isLoading={false}
+            dataSource={parameters}
+            columns={parametersColumns}
+            rowKey={(data, index) => data.name || `result-${index}`}
+            bordered
+          />
+        </Tabs.TabPane>
+      </Tabs>
     </div>
   );
 };
@@ -124,14 +138,15 @@ ResultsDrawer.propTypes = {
   activeKey: PropTypes.string,
   dataset: PropTypes.object,
   datasetScroll: PropTypes.object,
-  figures: PropTypes.arrayOf(PropTypes.object).isRequired,
+  figures: PropTypes.array.isRequired,
   isToShowDownloadButtons: PropTypes.bool,
   loading: PropTypes.bool.isRequired,
   onDatasetPageChange: PropTypes.func.isRequired,
   onTabChange: PropTypes.func.isRequired,
-  parameters: PropTypes.arrayOf(PropTypes.object),
+  parameters: PropTypes.array,
   scroll: PropTypes.object,
   resultsTabStyle: PropTypes.object,
+  handleDownloadResult: PropTypes.func,
 };
 
 ResultsDrawer.defaultProps = {

--- a/src/utils/Results.utils.js
+++ b/src/utils/Results.utils.js
@@ -72,3 +72,34 @@ export const formatResultsParameters = (parameters, parametersTraining) => {
 
   return resultsParameters;
 };
+
+/**
+ * Download the experiment run results
+ *
+ * @param {object} params parameters
+ * @param {string} params.projectId project id
+ * @param {string} params.experimentId experiment id
+ * @param {string} params.runId run id
+ * @param {string} params.operatorId operator id
+ */
+export const downloadExperimentRunResult = ({
+  projectId,
+  experimentId,
+  runId,
+  operatorId,
+}) => {
+  const urlParts = [
+    process.env.REACT_APP_PROJECTS_API,
+    'projects',
+    projectId,
+    'experiments',
+    experimentId,
+    'runs',
+    runId,
+    'operators',
+    operatorId,
+    'results',
+  ];
+
+  window.open(urlParts.join('/'), '_blank');
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -33,6 +33,7 @@ import {
   formatCompareResultDate,
   formatResultsParameters,
   transformResults,
+  downloadExperimentRunResult,
 } from './Results.utils';
 
 import {
@@ -76,6 +77,7 @@ export default {
   formatCompareResultDate,
   formatResultsParameters,
   transformResults,
+  downloadExperimentRunResult,
 
   configureOperatorParameters,
   checkOperatorSettedUp,


### PR DESCRIPTION
- Add a button in the OperatorResultsModal component to download the latest run results
- Add a dropdown item to download the results of the experiment, operator and run selected in the CompareResultsModal
- The download results button in the CompareResultsModal works, but it opens multiple browser tabs, so the browser may block this behavior (multiple popups)