### PR TITLE
Fix - Remove Unnecessary Modal Footer Buttons

### DIFF
--- a/src/components/LogsModal/LogsModal.component.jsx
+++ b/src/components/LogsModal/LogsModal.component.jsx
@@ -36,13 +36,12 @@ const LogsModal = ({ isShowing, handleHideModal, logs }) => {
 
   return (
     <Modal
-      cancelButtonProps={{ style: { display: 'none' } }}
       bodyStyle={{ padding: '0' }}
       wrapClassName='logs-modal'
       onCancel={handleHideModal}
       onOk={handleHideModal}
       visible={isShowing}
-      okText='Fechar'
+      footer={null}
       width={1000}
       title={
         <div className='logs-modal-header'>

--- a/src/components/Modals/DeploymentTestResultModal/DeploymentTestResultModal.component.jsx
+++ b/src/components/Modals/DeploymentTestResultModal/DeploymentTestResultModal.component.jsx
@@ -16,10 +16,9 @@ const DeploymentTestResultModal = ({
   return (
     <Modal
       width='70vw'
+      footer={null}
       visible={isShowingModal}
-      onOk={handleHideModal}
       onCancel={handleHideModal}
-      cancelButtonProps={{ style: { display: 'none' } }}
       title={<strong>Visualizar Resultados do Teste do Fluxo</strong>}
     >
       {isTestingFlow ? (

--- a/src/components/Modals/ExternalDatasetHelperModal/ExternalDatasetHelperModal.component.jsx
+++ b/src/components/Modals/ExternalDatasetHelperModal/ExternalDatasetHelperModal.component.jsx
@@ -18,16 +18,12 @@ const ExternalDatasetHelperModal = ({
 
   return (
     <Modal
-      visible={visible}
       title={<strong>Como usar uma aplicação como fonte de dados</strong>}
-      destroyOnClose
-      width={605}
       onCancel={onClose}
-      footer={[
-        <Button type='primary' key='back' onClick={onClose}>
-          Fechar
-        </Button>,
-      ]}
+      visible={visible}
+      footer={null}
+      width={605}
+      destroyOnClose
     >
       <p>
         Quando você implanta seu fluxo, a PlatIAgro cria um Serviço REST do{' '}

--- a/src/components/NotebooksExplanationModal/NotebooksExplanationModal.component.jsx
+++ b/src/components/NotebooksExplanationModal/NotebooksExplanationModal.component.jsx
@@ -8,13 +8,11 @@ const NotebooksExplanationModal = ({ isShowingModal, handleHideModal }) => {
       bodyStyle={{ padding: '24px', textAlign: 'justify' }}
       wrapClassName='notebooks-explanation-modal'
       okText='Ok'
+      footer={null}
       onOk={handleHideModal}
       visible={isShowingModal}
       onCancel={handleHideModal}
       title={<strong>Saiba Mais Sobre Notebooks</strong>}
-      cancelButtonProps={{
-        style: { display: 'none' },
-      }}
       centered
     >
       <h2>O que são Notebooks</h2>

--- a/src/containers/DataViewModalContainer/DataViewModalContainer.jsx
+++ b/src/containers/DataViewModalContainer/DataViewModalContainer.jsx
@@ -57,10 +57,6 @@ const datasetOperatorSelector = ({ operatorReducer }) => {
   return operatorReducer;
 };
 
-const isFullScreen = true;
-const closeButtonText = 'Fechar';
-const title = 'Visualizar dados';
-
 const DataViewModalContainer = () => {
   const dispatch = useDispatch();
 
@@ -158,11 +154,11 @@ const DataViewModalContainer = () => {
   return (
     <Modal
       className='dataViewModalParent'
-      closeButtonText={closeButtonText}
-      isFullScreen={isFullScreen}
       handleClose={handleClose}
+      title='Visualizar dados'
       isVisible={isVisible}
-      title={title}
+      footer={null}
+      isFullScreen
     >
       <div className='dataViewModal'>
         <div className='dataViewModalDataHeader'>

--- a/src/containers/OperatorResultsModalContainer/OperatorResultsModalContainer.jsx
+++ b/src/containers/OperatorResultsModalContainer/OperatorResultsModalContainer.jsx
@@ -108,9 +108,9 @@ const OperatorResultsModalContainer = () => {
 
   return (
     <Modal
+      footer={null}
       isFullScreen={true}
       isVisible={isVisible}
-      closeButtonText='Fechar'
       handleClose={handleClose}
       title='Visualizar Resultados'
     >


### PR DESCRIPTION
- Remove the modal footer from LogsModal
- Remove the modal footer from DeploymentTestResultModal
- Remove the modal footer from ExternalDatasetHelperModal
- Remove the modal footer from NotebooksExplanationModal
- Remove the modal footer from DataViewModalContainer/DataViewModalContainer
- Remove the modal footer from OperatorResultsModalContainer/OperatorResultsModalContainer