### PR TITLE
Handles error when creating a deployment

### DIFF
--- a/src/store/deployments/actions.js
+++ b/src/store/deployments/actions.js
@@ -19,6 +19,7 @@ import {
 import { addLoading, removeLoading } from 'store/loading';
 
 const ALREADY_EXIST_MESSAGE = 'Já existe uma pré-implantação com este nome!';
+const AT_LEAST_ONE_OPERATOR_MESSAGE = 'O experimento selecionado deve possuir pelo menos um operador!';
 
 // ACTIONS
 // ** FETCH DEPLOYMENTS
@@ -121,9 +122,11 @@ const createDeploymentFail = (error) => (dispatch) => {
     errorMessage,
   });
 
-  errorMessage = errorMessage.includes('either')
-    ? customErrorMessage
-    : errorMessage;
+  if (errorMessage.includes('either')) {
+    errorMessage = customErrorMessage;
+  } else if (errorMessage.includes('at least one operator')) {
+    errorMessage = AT_LEAST_ONE_OPERATOR_MESSAGE;
+  }
 
   message.error(errorMessage, 5);
 };


### PR DESCRIPTION
Uses a custom message when the api returns 400 'Necessary at least one operator'.