### PR TITLE
Fix/Change notification name to operator name

### DIFF
--- a/src/pages/Experiments/useShowOperatorStatusNotifications.js
+++ b/src/pages/Experiments/useShowOperatorStatusNotifications.js
@@ -35,7 +35,7 @@ export default () => {
         notification.open({
           key,
           duration: 0,
-          message: operator.task?.name,
+          message: operator?.name,
           description: operator.statusMessage,
         });
       }


### PR DESCRIPTION
Changed name on notification message to operator's name instead of task's name