### PR TITLE
Fix - Experiment Logs Panel Loading

### DIFF
--- a/src/containers/ExperimentLogsPanelContainer/ExperimentLogsPanelContainer.jsx
+++ b/src/containers/ExperimentLogsPanelContainer/ExperimentLogsPanelContainer.jsx
@@ -59,16 +59,19 @@ const ExperimentLogsPanelContainer = () => {
     setIsShowingModal(false);
   };
 
-  const handleFetchLogs = useCallback(() => {
-    if (!projectId || !experimentId) return;
-    dispatch(getExperimentLogs(projectId, experimentId));
-  }, [dispatch, experimentId, projectId]);
+  const handleFetchLogs = useCallback(
+    (shouldShowLoading = true) => {
+      if (!projectId || !experimentId) return;
+      dispatch(getExperimentLogs(projectId, experimentId, shouldShowLoading));
+    },
+    [dispatch, experimentId, projectId]
+  );
 
   useEffect(handleFetchLogs, [handleFetchLogs]);
 
   useEffect(() => {
     const polling = setInterval(() => {
-      handleFetchLogs();
+      handleFetchLogs(false);
     }, 5000);
 
     return () => clearInterval(polling);

--- a/src/store/experimentLogs/actions.js
+++ b/src/store/experimentLogs/actions.js
@@ -45,29 +45,30 @@ const setIsLoadingLogs = (isLoading = false) => ({
  *
  * @param {string} projectId Project ID
  * @param {string} experimentId Deployment ID
+ * @param {boolean} shouldShowLoading Should show loading
  * @returns {Function} Dispatch function
  */
-export const getExperimentLogs = (projectId, experimentId) => async (
-  dispatch
-) => {
-  try {
-    dispatch(setIsLoadingLogs(true));
+export const getExperimentLogs =
+  (projectId, experimentId, shouldShowLoading = true) =>
+  async (dispatch) => {
+    try {
+      if (shouldShowLoading) dispatch(setIsLoadingLogs(true));
 
-    const response = await experimentRunsApi.fetchExperimentLogs(
-      projectId,
-      experimentId,
-      'latest'
-    );
+      const response = await experimentRunsApi.fetchExperimentLogs(
+        projectId,
+        experimentId,
+        'latest'
+      );
 
-    const logs = response.data?.logs || [];
-    dispatch(getExperimentLogsSucceed(logs));
-  } catch (e) {
-    dispatch(getExperimentLogsFailed());
-    message.error(utils.getErrorMessage(e), 5);
-  } finally {
-    dispatch(setIsLoadingLogs(false));
-  }
-};
+      const logs = response.data?.logs || [];
+      dispatch(getExperimentLogsSucceed(logs));
+    } catch (e) {
+      dispatch(getExperimentLogsFailed());
+      message.error(utils.getErrorMessage(e), 5);
+    } finally {
+      dispatch(setIsLoadingLogs(false));
+    }
+  };
 
 /**
  * Clear all experiment logs


### PR DESCRIPTION
- Hide loading component when running the experiment logs polling request

P.S. The deployment logs panel already has the same behavior.