### PR TITLE
Fix - Redirection to Login if Response Status is 302

### DIFF
--- a/src/services/CompareResultsApi.js
+++ b/src/services/CompareResultsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const comparisonsApi = axios.create({
+const comparisonsApi = createAxiosInstance({
   baseURL: `${URL}/projects`,
 });
-
-comparisonsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const comparisonsPath = '/comparisons';
 

--- a/src/services/CompareResultsApi.js
+++ b/src/services/CompareResultsApi.js
@@ -9,8 +9,8 @@ const comparisonsApi = axios.create({
 });
 
 comparisonsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const comparisonsPath = '/comparisons';

--- a/src/services/CompareResultsApi.js
+++ b/src/services/CompareResultsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
 const comparisonsApi = axios.create({
   baseURL: `${URL}/projects`,
 });
+
+comparisonsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const comparisonsPath = '/comparisons';
 
@@ -61,4 +68,5 @@ export default {
   deleteCompareResult,
   listCompareResult,
   updateCompareResult,
+  axiosInstance: comparisonsApi,
 };

--- a/src/services/DatasetsApi.js
+++ b/src/services/DatasetsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_DATASET_API || 'http://localhost:8080';
 
-const datasetsApi = axios.create({
+const datasetsApi = createAxiosInstance({
   baseURL: URL,
 });
-
-datasetsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const datasetsPath = '/datasets';
 

--- a/src/services/DatasetsApi.js
+++ b/src/services/DatasetsApi.js
@@ -9,8 +9,8 @@ const datasetsApi = axios.create({
 });
 
 datasetsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const datasetsPath = '/datasets';

--- a/src/services/DatasetsApi.js
+++ b/src/services/DatasetsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_DATASET_API || 'http://localhost:8080';
 
 const datasetsApi = axios.create({
   baseURL: URL,
 });
+
+datasetsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const datasetsPath = '/datasets';
 
@@ -97,4 +104,5 @@ export default {
   getDataset,
   getDatasetFeaturetypes,
   createDataset,
+  axiosInstance: datasetsApi,
 };

--- a/src/services/DeploymentRunsApi.js
+++ b/src/services/DeploymentRunsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const deploymentRunsApi = axios.create({
+const deploymentRunsApi = createAxiosInstance({
   baseURL: `${URL}/projects/`,
 });
-
-deploymentRunsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const deploymentsPath = 'deployments';
 const runsPath = 'runs';

--- a/src/services/DeploymentRunsApi.js
+++ b/src/services/DeploymentRunsApi.js
@@ -9,8 +9,8 @@ const deploymentRunsApi = axios.create({
 });
 
 deploymentRunsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const deploymentsPath = 'deployments';

--- a/src/services/DeploymentRunsApi.js
+++ b/src/services/DeploymentRunsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const projectsApi = axios.create({
+const deploymentRunsApi = axios.create({
   baseURL: `${URL}/projects/`,
 });
+
+deploymentRunsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const deploymentsPath = 'deployments';
 const runsPath = 'runs';
@@ -17,7 +24,7 @@ const runsPath = 'runs';
  * @returns {Promise} Request Promise
  */
 const listDeploymentRuns = (projectId, deploymentId) => {
-  return projectsApi.get(
+  return deploymentRunsApi.get(
     `${projectId}/${deploymentsPath}/${deploymentId}/${runsPath}`
   );
 };
@@ -31,7 +38,7 @@ const listDeploymentRuns = (projectId, deploymentId) => {
  * @returns {Promise} Request Promise
  */
 const fetchDeploymentRun = (projectId, deploymentId, runId) => {
-  return projectsApi.get(
+  return deploymentRunsApi.get(
     `${projectId}/${deploymentsPath}/${deploymentId}/${runsPath}/${runId}`
   );
 };
@@ -44,7 +51,7 @@ const fetchDeploymentRun = (projectId, deploymentId, runId) => {
  * @returns {Promise} Request Promise
  */
 const createDeploymentRun = (projectId, deploymentId) => {
-  return projectsApi.post(
+  return deploymentRunsApi.post(
     `${projectId}/${deploymentsPath}/${deploymentId}/${runsPath}`
   );
 };
@@ -58,7 +65,7 @@ const createDeploymentRun = (projectId, deploymentId) => {
  * @returns {Promise} Request Promise
  */
 const deleteDeploymentRun = (projectId, deploymentId, runId) => {
-  return projectsApi.delete(
+  return deploymentRunsApi.delete(
     `${projectId}/${deploymentsPath}/${deploymentId}/${runsPath}/${runId}`
   );
 };
@@ -72,7 +79,7 @@ const deleteDeploymentRun = (projectId, deploymentId, runId) => {
  * @returns {Promise} Request Promise
  */
 const fetchDeploymentRunLogs = (projectId, deploymentId, runId) => {
-  return projectsApi.get(
+  return deploymentRunsApi.get(
     `${projectId}/${deploymentsPath}/${deploymentId}/${runsPath}/${runId}/logs`
   );
 };
@@ -86,7 +93,7 @@ const fetchDeploymentRunLogs = (projectId, deploymentId, runId) => {
  * @returns {Promise} Request Promise
  */
 const retryDeploymentRun = (projectId, deploymentId, runId) => {
-  return projectsApi.put(
+  return deploymentRunsApi.put(
     `${projectId}/${deploymentsPath}/${deploymentId}/${runsPath}/${runId}/retry`
   );
 };
@@ -98,5 +105,5 @@ export default {
   fetchDeploymentRunLogs,
   listDeploymentRuns,
   retryDeploymentRun,
-  axiosInstance: projectsApi,
+  axiosInstance: deploymentRunsApi,
 };

--- a/src/services/DeploymentsApi.js
+++ b/src/services/DeploymentsApi.js
@@ -9,8 +9,8 @@ const deploymentsApi = axios.create({
 });
 
 deploymentsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const deploymentsPath = 'deployments';

--- a/src/services/DeploymentsApi.js
+++ b/src/services/DeploymentsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const projectsApi = axios.create({
+const deploymentsApi = axios.create({
   baseURL: `${URL}/projects/`,
 });
+
+deploymentsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const deploymentsPath = 'deployments';
 
@@ -15,7 +22,7 @@ const deploymentsPath = 'deployments';
  * @returns {Promise} Request Promise
  */
 const listDeployments = (projectId) => {
-  return projectsApi.get(`${projectId}/${deploymentsPath}`);
+  return deploymentsApi.get(`${projectId}/${deploymentsPath}`);
 };
 
 /**
@@ -26,7 +33,7 @@ const listDeployments = (projectId) => {
  * @returns {Promise} Request Promise
  */
 const createDeployment = (projectId, body) => {
-  return projectsApi.post(`${projectId}/${deploymentsPath}`, body);
+  return deploymentsApi.post(`${projectId}/${deploymentsPath}`, body);
 };
 
 /**
@@ -37,7 +44,7 @@ const createDeployment = (projectId, body) => {
  * @returns {Promise} Request Promise
  */
 const getDeployment = (projectId, deploymentId) => {
-  return projectsApi.get(`${projectId}/${deploymentsPath}/${deploymentId}`);
+  return deploymentsApi.get(`${projectId}/${deploymentsPath}/${deploymentId}`);
 };
 
 /**
@@ -49,7 +56,7 @@ const getDeployment = (projectId, deploymentId) => {
  * @returns {Promise} Request Promise
  */
 const updateDeployment = (projectId, deploymentId, deploymentObj) => {
-  return projectsApi.patch(
+  return deploymentsApi.patch(
     `${projectId}/${deploymentsPath}/${deploymentId}`,
     deploymentObj
   );
@@ -63,7 +70,9 @@ const updateDeployment = (projectId, deploymentId, deploymentObj) => {
  * @returns {Promise} Request Promise
  */
 const deleteDeployment = (projectId, deploymentId) => {
-  return projectsApi.delete(`${projectId}/${deploymentsPath}/${deploymentId}`);
+  return deploymentsApi.delete(
+    `${projectId}/${deploymentsPath}/${deploymentId}`
+  );
 };
 
 /**
@@ -81,7 +90,7 @@ const updateDeploymentOperator = (
   operatorId,
   operatorObj
 ) => {
-  return projectsApi.patch(
+  return deploymentsApi.patch(
     `${projectId}/${deploymentsPath}/${deploymentId}/operators/${operatorId}`,
     operatorObj
   );
@@ -98,7 +107,7 @@ const updateDeploymentOperator = (
 const testDeploymentWithFile = (projectId, deploymentId, file) => {
   const form = new FormData();
   form.append('file', file);
-  return projectsApi.post(
+  return deploymentsApi.post(
     `${projectId}/${deploymentsPath}/${deploymentId}/predictions`,
     form
   );
@@ -113,7 +122,7 @@ const testDeploymentWithFile = (projectId, deploymentId, file) => {
  * @returns {Promise} Request Promise
  */
 const testDeploymentWithDataset = (projectId, deploymentId, dataset) => {
-  return projectsApi.post(
+  return deploymentsApi.post(
     `${projectId}/${deploymentsPath}/${deploymentId}/predictions`,
     { dataset }
   );
@@ -128,4 +137,5 @@ export default {
   updateDeploymentOperator,
   testDeploymentWithFile,
   testDeploymentWithDataset,
+  axiosInstance: deploymentsApi,
 };

--- a/src/services/DeploymentsApi.js
+++ b/src/services/DeploymentsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const deploymentsApi = axios.create({
+const deploymentsApi = createAxiosInstance({
   baseURL: `${URL}/projects/`,
 });
-
-deploymentsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const deploymentsPath = 'deployments';
 

--- a/src/services/DeploymentsOperatorsApi.js
+++ b/src/services/DeploymentsOperatorsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const deploymentsOperatorsApi = axios.create({
+const deploymentsOperatorsApi = createAxiosInstance({
   baseURL: `${URL}/projects/`,
 });
-
-deploymentsOperatorsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const deploymentsPath = 'deployments';
 const operatorsPath = 'operators';

--- a/src/services/DeploymentsOperatorsApi.js
+++ b/src/services/DeploymentsOperatorsApi.js
@@ -9,8 +9,8 @@ const deploymentsOperatorsApi = axios.create({
 });
 
 deploymentsOperatorsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const deploymentsPath = 'deployments';

--- a/src/services/DeploymentsOperatorsApi.js
+++ b/src/services/DeploymentsOperatorsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const operatorsApi = axios.create({
+const deploymentsOperatorsApi = axios.create({
   baseURL: `${URL}/projects/`,
 });
+
+deploymentsOperatorsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const deploymentsPath = 'deployments';
 const operatorsPath = 'operators';
@@ -17,7 +24,7 @@ const operatorsPath = 'operators';
  * @returns {Promise} Request Promise
  */
 const listOperators = (projectId, deploymentId) => {
-  return operatorsApi.get(
+  return deploymentsOperatorsApi.get(
     `${projectId}/${deploymentsPath}/${deploymentId}/${operatorsPath}`
   );
 };
@@ -47,7 +54,7 @@ const createOperator = (
     positionX: position.x,
     positionY: position.y,
   };
-  return operatorsApi.post(
+  return deploymentsOperatorsApi.post(
     `${projectId}/${deploymentsPath}/${deploymentId}/${operatorsPath}`,
     body
   );
@@ -62,7 +69,7 @@ const createOperator = (
  * @returns {Promise} Request Promise
  */
 const deleteOperator = (projectId, deploymentId, operatorId) => {
-  return operatorsApi.delete(
+  return deploymentsOperatorsApi.delete(
     `${projectId}/${deploymentsPath}/${deploymentId}/${operatorsPath}/${operatorId}`
   );
 };
@@ -77,7 +84,7 @@ const deleteOperator = (projectId, deploymentId, operatorId) => {
  * @returns {Promise} Request Promise
  */
 const updateOperator = (projectId, deploymentId, operatorId, operator) => {
-  return operatorsApi.patch(
+  return deploymentsOperatorsApi.patch(
     `${projectId}/${deploymentsPath}/${deploymentId}/${operatorsPath}/${operatorId}`,
     operator
   );
@@ -88,4 +95,5 @@ export default {
   createOperator,
   deleteOperator,
   updateOperator,
+  axiosInstance: deploymentsOperatorsApi,
 };

--- a/src/services/ExperimentRunsApi.js
+++ b/src/services/ExperimentRunsApi.js
@@ -9,8 +9,8 @@ const experimentRunsApi = axios.create({
 });
 
 experimentRunsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const experimentsPath = 'experiments';

--- a/src/services/ExperimentRunsApi.js
+++ b/src/services/ExperimentRunsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const experimentRunsApi = axios.create({
+const experimentRunsApi = createAxiosInstance({
   baseURL: `${URL}/projects/`,
 });
-
-experimentRunsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const experimentsPath = 'experiments';
 const runsPath = 'runs';

--- a/src/services/ExperimentRunsApi.js
+++ b/src/services/ExperimentRunsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-export const projectsApi = axios.create({
+const experimentRunsApi = axios.create({
   baseURL: `${URL}/projects/`,
 });
+
+experimentRunsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const experimentsPath = 'experiments';
 const runsPath = 'runs';
@@ -17,7 +24,7 @@ const runsPath = 'runs';
  * @returns {Promise} Request Promise
  */
 const fetchExperimentRuns = (projectId, experimentId) => {
-  return projectsApi.get(
+  return experimentRunsApi.get(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}`
   );
 };
@@ -31,7 +38,7 @@ const fetchExperimentRuns = (projectId, experimentId) => {
  * @returns {Promise} Request Promise
  */
 const fetchExperimentRunStatus = (projectId, experimentId, runId) => {
-  return projectsApi.get(
+  return experimentRunsApi.get(
     `${projectId}/${experimentsPath}/${experimentId}/runs/${runId}`
   );
 };
@@ -44,7 +51,7 @@ const fetchExperimentRunStatus = (projectId, experimentId, runId) => {
  * @returns {Promise} Request Promise
  */
 const createExperimentRun = (projectId, experimentId) => {
-  return projectsApi.post(
+  return experimentRunsApi.post(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}`
   );
 };
@@ -57,7 +64,7 @@ const createExperimentRun = (projectId, experimentId) => {
  * @returns {Promise} Request Promise
  */
 const deleteExperimentRun = (projectId, experimentId) => {
-  return projectsApi.delete(
+  return experimentRunsApi.delete(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}/latest`
   );
 };
@@ -71,7 +78,7 @@ const deleteExperimentRun = (projectId, experimentId) => {
  * @returns {Promise} Request Promise
  */
 const retryExperimentRun = (projectId, experimentId, runId) => {
-  return projectsApi.put(
+  return experimentRunsApi.put(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}${runId}/retry`
   );
 };
@@ -97,7 +104,7 @@ const listOperatorDatasets = (
   page = 1,
   pageSize = 10
 ) => {
-  return projectsApi.get(
+  return experimentRunsApi.get(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}/${runId}/operators/${operatorId}/datasets?page=${page}&page_size=${pageSize}`
   );
 };
@@ -112,7 +119,7 @@ const listOperatorDatasets = (
  * @returns {Promise} Request Promise
  */
 const listOperatorFigures = (projectId, experimentId, runId, operatorId) => {
-  return projectsApi.get(
+  return experimentRunsApi.get(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}/${runId}/operators/${operatorId}/figures`
   );
 };
@@ -127,7 +134,7 @@ const listOperatorFigures = (projectId, experimentId, runId, operatorId) => {
  * @returns {Promise} Request Promise
  */
 const fetchOperatorLogs = (projectId, experimentId, runId, operatorId) => {
-  return projectsApi.get(
+  return experimentRunsApi.get(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}/${runId}/operators/${operatorId}/logs`
   );
 };
@@ -141,7 +148,7 @@ const fetchOperatorLogs = (projectId, experimentId, runId, operatorId) => {
  * @returns {Promise} Request Promise
  */
 const fetchExperimentLogs = (projectId, experimentId, runId) => {
-  return projectsApi.get(
+  return experimentRunsApi.get(
     `${projectId}/${experimentsPath}/${experimentId}/${runsPath}/${runId}/logs`
   );
 };
@@ -156,5 +163,5 @@ export default {
   listOperatorFigures,
   fetchOperatorLogs,
   fetchExperimentLogs,
-  axiosInstance: projectsApi,
+  axiosInstance: experimentRunsApi,
 };

--- a/src/services/ExperimentsApi.js
+++ b/src/services/ExperimentsApi.js
@@ -6,6 +6,8 @@
 
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
 const projectsPath = '/projects';
@@ -13,6 +15,11 @@ const projectsPath = '/projects';
 const experimentsApi = axios.create({
   baseURL: `${URL}${projectsPath}`,
 });
+
+experimentsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const experimentsPath = '/experiments';
 
@@ -82,4 +89,5 @@ export default {
   createExperiment,
   updateExperiment,
   deleteExperiment,
+  axiosInstance: experimentsApi,
 };

--- a/src/services/ExperimentsApi.js
+++ b/src/services/ExperimentsApi.js
@@ -17,8 +17,8 @@ const experimentsApi = axios.create({
 });
 
 experimentsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const experimentsPath = '/experiments';

--- a/src/services/ExperimentsApi.js
+++ b/src/services/ExperimentsApi.js
@@ -4,22 +4,15 @@
 
 /* API REFERENCE: https://platiagro.github.io/projects/#/Experiments */
 
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
 const projectsPath = '/projects';
 
-const experimentsApi = axios.create({
+const experimentsApi = createAxiosInstance({
   baseURL: `${URL}${projectsPath}`,
 });
-
-experimentsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const experimentsPath = '/experiments';
 

--- a/src/services/JupyterLabApi.js
+++ b/src/services/JupyterLabApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_JUPYTER_API || 'http://localhost:8080';
 
-const jupyterLabApi = axios.create({
+const jupyterLabApi = createAxiosInstance({
   baseURL: URL,
 });
-
-jupyterLabApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const healthCheckPath = '/api';
 

--- a/src/services/JupyterLabApi.js
+++ b/src/services/JupyterLabApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
-export const URL = process.env.REACT_APP_JUPYTER_API || 'http://localhost:8080';
+import { AuthExpiredInterceptor } from './interceptors';
 
-export const jupyterLabApi = axios.create({
+const URL = process.env.REACT_APP_JUPYTER_API || 'http://localhost:8080';
+
+const jupyterLabApi = axios.create({
   baseURL: URL,
 });
+
+jupyterLabApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const healthCheckPath = '/api';
 
@@ -19,4 +26,5 @@ const healthCheck = () => {
 
 export default {
   healthCheck,
+  axiosInstance: jupyterLabApi,
 };

--- a/src/services/JupyterLabApi.js
+++ b/src/services/JupyterLabApi.js
@@ -9,8 +9,8 @@ const jupyterLabApi = axios.create({
 });
 
 jupyterLabApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const healthCheckPath = '/api';

--- a/src/services/MonitoringsApi.js
+++ b/src/services/MonitoringsApi.js
@@ -7,8 +7,8 @@ const monitoringsApi = axios.create({
 });
 
 monitoringsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const getBaseUrl = (projectId, deploymentId) => {

--- a/src/services/MonitoringsApi.js
+++ b/src/services/MonitoringsApi.js
@@ -1,8 +1,15 @@
 import axios from 'axios';
 
-export const monitoringsApi = axios.create({
+import { AuthExpiredInterceptor } from './interceptors';
+
+const monitoringsApi = axios.create({
   baseURL: process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080',
 });
+
+monitoringsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const getBaseUrl = (projectId, deploymentId) => {
   return `projects/${projectId}/deployments/${deploymentId}/monitorings`;
@@ -71,4 +78,5 @@ export default {
   createMonitoring,
   deleteMonitoring,
   fetchMonitoringFigures,
+  axiosInstance: monitoringsApi,
 };

--- a/src/services/MonitoringsApi.js
+++ b/src/services/MonitoringsApi.js
@@ -1,15 +1,8 @@
-import axios from 'axios';
+import { createAxiosInstance } from 'services/factories';
 
-import { AuthExpiredInterceptor } from './interceptors';
-
-const monitoringsApi = axios.create({
+const monitoringsApi = createAxiosInstance({
   baseURL: process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080',
 });
-
-monitoringsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const getBaseUrl = (projectId, deploymentId) => {
   return `projects/${projectId}/deployments/${deploymentId}/monitorings`;

--- a/src/services/OperatorsApi.js
+++ b/src/services/OperatorsApi.js
@@ -9,8 +9,8 @@ const operatorsApi = axios.create({
 });
 
 operatorsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const experimentsPath = '/experiments';

--- a/src/services/OperatorsApi.js
+++ b/src/services/OperatorsApi.js
@@ -1,10 +1,17 @@
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
 const operatorsApi = axios.create({
   baseURL: `${URL}/projects`,
 });
+
+operatorsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const experimentsPath = '/experiments';
 const operatorsPath = '/operators';
@@ -97,4 +104,5 @@ export default {
   deleteOperator,
   updateOperator,
   updateOperatorParameter,
+  axiosInstance: operatorsApi,
 };

--- a/src/services/OperatorsApi.js
+++ b/src/services/OperatorsApi.js
@@ -1,17 +1,10 @@
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const operatorsApi = axios.create({
+const operatorsApi = createAxiosInstance({
   baseURL: `${URL}/projects`,
 });
-
-operatorsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const experimentsPath = '/experiments';
 const operatorsPath = '/operators';

--- a/src/services/ProjectsApi.js
+++ b/src/services/ProjectsApi.js
@@ -4,20 +4,13 @@
 
 /* API REFERENCE: https://platiagro.github.io/projects/#/Projects */
 
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const projectsApi = axios.create({
+const projectsApi = createAxiosInstance({
   baseURL: URL,
 });
-
-projectsApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const projectsPath = '/projects';
 

--- a/src/services/ProjectsApi.js
+++ b/src/services/ProjectsApi.js
@@ -6,11 +6,18 @@
 
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
 const projectsApi = axios.create({
   baseURL: URL,
 });
+
+projectsApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const projectsPath = '/projects';
 
@@ -75,4 +82,5 @@ export default {
   updateProject,
   deleteProjects,
   fetchPaginatedProjects,
+  axiosInstance: projectsApi,
 };

--- a/src/services/ProjectsApi.js
+++ b/src/services/ProjectsApi.js
@@ -15,8 +15,8 @@ const projectsApi = axios.create({
 });
 
 projectsApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const projectsPath = '/projects';

--- a/src/services/TasksApi.js
+++ b/src/services/TasksApi.js
@@ -1,8 +1,15 @@
 import axios from 'axios';
 
-export const taskApi = axios.create({
+import { AuthExpiredInterceptor } from './interceptors';
+
+const taskApi = axios.create({
   baseURL: process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080',
 });
+
+taskApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 /**
  * Create task

--- a/src/services/TasksApi.js
+++ b/src/services/TasksApi.js
@@ -7,8 +7,8 @@ const taskApi = axios.create({
 });
 
 taskApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 /**

--- a/src/services/TasksApi.js
+++ b/src/services/TasksApi.js
@@ -1,15 +1,8 @@
-import axios from 'axios';
+import { createAxiosInstance } from 'services/factories';
 
-import { AuthExpiredInterceptor } from './interceptors';
-
-const taskApi = axios.create({
+const taskApi = createAxiosInstance({
   baseURL: process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080',
 });
-
-taskApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 /**
  * Create task

--- a/src/services/TemplatesApi.js
+++ b/src/services/TemplatesApi.js
@@ -4,20 +4,13 @@
 
 /* API REFERENCE: https://platiagro.github.io/projects/#/Templates */
 
-import axios from 'axios';
-
-import { AuthExpiredInterceptor } from './interceptors';
+import { createAxiosInstance } from 'services/factories';
 
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
-const templatesApi = axios.create({
+const templatesApi = createAxiosInstance({
   baseURL: URL,
 });
-
-templatesApi.interceptors.response.use(
-  AuthExpiredInterceptor.Response.onFulfilled,
-  AuthExpiredInterceptor.Response.onRejected
-);
 
 const templatesPath = '/templates';
 

--- a/src/services/TemplatesApi.js
+++ b/src/services/TemplatesApi.js
@@ -6,11 +6,18 @@
 
 import axios from 'axios';
 
+import { AuthExpiredInterceptor } from './interceptors';
+
 const URL = process.env.REACT_APP_PROJECTS_API || 'http://localhost:8080';
 
 const templatesApi = axios.create({
   baseURL: URL,
 });
+
+templatesApi.interceptors.response.use(
+  undefined,
+  AuthExpiredInterceptor.response.onRejected
+);
 
 const templatesPath = '/templates';
 
@@ -62,4 +69,5 @@ export default {
   createTemplate,
   updateTemplate,
   deleteTemplate,
+  axiosInstance: templatesApi,
 };

--- a/src/services/TemplatesApi.js
+++ b/src/services/TemplatesApi.js
@@ -15,8 +15,8 @@ const templatesApi = axios.create({
 });
 
 templatesApi.interceptors.response.use(
-  undefined,
-  AuthExpiredInterceptor.response.onRejected
+  AuthExpiredInterceptor.Response.onFulfilled,
+  AuthExpiredInterceptor.Response.onRejected
 );
 
 const templatesPath = '/templates';

--- a/src/services/__tests__/CompareResultsApi.test.js
+++ b/src/services/__tests__/CompareResultsApi.test.js
@@ -1,7 +1,14 @@
-import compareResultsApi from '../CompareResultsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import compareResultsApi from 'services/CompareResultsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('CompareResultsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(compareResultsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/CompareResultsApi.test.js
+++ b/src/services/__tests__/CompareResultsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('CompareResultsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(

--- a/src/services/__tests__/CompareResultsApi.test.js
+++ b/src/services/__tests__/CompareResultsApi.test.js
@@ -1,0 +1,15 @@
+import compareResultsApi from '../CompareResultsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('CompareResultsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(
+      compareResultsApi.axiosInstance.interceptors.response.handlers
+    ).toEqual([interceptor]);
+  });
+});

--- a/src/services/__tests__/DatasetsApi.test.js
+++ b/src/services/__tests__/DatasetsApi.test.js
@@ -1,0 +1,15 @@
+import datasetsApi from '../DatasetsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('DatasetsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(datasetsApi.axiosInstance.interceptors.response.handlers).toEqual([
+      interceptor,
+    ]);
+  });
+});

--- a/src/services/__tests__/DatasetsApi.test.js
+++ b/src/services/__tests__/DatasetsApi.test.js
@@ -1,7 +1,14 @@
-import datasetsApi from '../DatasetsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import datasetsApi from 'services/DatasetsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('DatasetsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(datasetsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/DatasetsApi.test.js
+++ b/src/services/__tests__/DatasetsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('DatasetsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(datasetsApi.axiosInstance.interceptors.response.handlers).toEqual([

--- a/src/services/__tests__/DeploymentRunsApi.test.js
+++ b/src/services/__tests__/DeploymentRunsApi.test.js
@@ -1,0 +1,15 @@
+import deploymentRunsApi from '../DeploymentRunsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('DeploymentRunsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(
+      deploymentRunsApi.axiosInstance.interceptors.response.handlers
+    ).toEqual([interceptor]);
+  });
+});

--- a/src/services/__tests__/DeploymentRunsApi.test.js
+++ b/src/services/__tests__/DeploymentRunsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('DeploymentRunsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(

--- a/src/services/__tests__/DeploymentRunsApi.test.js
+++ b/src/services/__tests__/DeploymentRunsApi.test.js
@@ -1,7 +1,14 @@
-import deploymentRunsApi from '../DeploymentRunsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import deploymentRunsApi from 'services/DeploymentRunsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('DeploymentRunsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(deploymentRunsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/DeploymentsApi.test.js
+++ b/src/services/__tests__/DeploymentsApi.test.js
@@ -1,0 +1,15 @@
+import deploymentsApi from '../DeploymentsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('DeploymentsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(deploymentsApi.axiosInstance.interceptors.response.handlers).toEqual(
+      [interceptor]
+    );
+  });
+});

--- a/src/services/__tests__/DeploymentsApi.test.js
+++ b/src/services/__tests__/DeploymentsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('DeploymentsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(deploymentsApi.axiosInstance.interceptors.response.handlers).toEqual(

--- a/src/services/__tests__/DeploymentsApi.test.js
+++ b/src/services/__tests__/DeploymentsApi.test.js
@@ -1,7 +1,14 @@
-import deploymentsApi from '../DeploymentsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import deploymentsApi from 'services/DeploymentsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('DeploymentsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(deploymentsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/DeploymentsOperatorsApi.test.js
+++ b/src/services/__tests__/DeploymentsOperatorsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('DeploymentsOperatorsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(

--- a/src/services/__tests__/DeploymentsOperatorsApi.test.js
+++ b/src/services/__tests__/DeploymentsOperatorsApi.test.js
@@ -1,7 +1,14 @@
-import deploymentsOperatorsApi from '../DeploymentsOperatorsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import deploymentsOperatorsApi from 'services/DeploymentsOperatorsApi';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('DeploymentsOperatorsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(deploymentsOperatorsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/DeploymentsOperatorsApi.test.js
+++ b/src/services/__tests__/DeploymentsOperatorsApi.test.js
@@ -1,0 +1,15 @@
+import deploymentsOperatorsApi from '../DeploymentsOperatorsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('DeploymentsOperatorsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(
+      deploymentsOperatorsApi.axiosInstance.interceptors.response.handlers
+    ).toEqual([interceptor]);
+  });
+});

--- a/src/services/__tests__/ExperimentRunsApi.test.js
+++ b/src/services/__tests__/ExperimentRunsApi.test.js
@@ -1,0 +1,15 @@
+import experimentRunsApi from '../ExperimentRunsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('ExperimentRunsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(
+      experimentRunsApi.axiosInstance.interceptors.response.handlers
+    ).toEqual([interceptor]);
+  });
+});

--- a/src/services/__tests__/ExperimentRunsApi.test.js
+++ b/src/services/__tests__/ExperimentRunsApi.test.js
@@ -1,7 +1,14 @@
-import experimentRunsApi from '../ExperimentRunsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import experimentRunsApi from 'services/ExperimentRunsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('ExperimentRunsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(experimentRunsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/ExperimentRunsApi.test.js
+++ b/src/services/__tests__/ExperimentRunsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('ExperimentRunsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(

--- a/src/services/__tests__/ExperimentsApi.test.js
+++ b/src/services/__tests__/ExperimentsApi.test.js
@@ -1,7 +1,14 @@
-import experimentsApi from '../ExperimentsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import experimentsApi from 'services/ExperimentsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('ExperimentsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(experimentsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/ExperimentsApi.test.js
+++ b/src/services/__tests__/ExperimentsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('ExperimentsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(experimentsApi.axiosInstance.interceptors.response.handlers).toEqual(

--- a/src/services/__tests__/ExperimentsApi.test.js
+++ b/src/services/__tests__/ExperimentsApi.test.js
@@ -1,0 +1,15 @@
+import experimentsApi from '../ExperimentsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('ExperimentsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(experimentsApi.axiosInstance.interceptors.response.handlers).toEqual(
+      [interceptor]
+    );
+  });
+});

--- a/src/services/__tests__/JupyterLabApi.test.js
+++ b/src/services/__tests__/JupyterLabApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('JupyterLabApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(jupyterLabApi.axiosInstance.interceptors.response.handlers).toEqual([

--- a/src/services/__tests__/JupyterLabApi.test.js
+++ b/src/services/__tests__/JupyterLabApi.test.js
@@ -1,7 +1,14 @@
-import jupyterLabApi from '../JupyterLabApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import jupyterLabApi from 'services/JupyterLabApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('JupyterLabApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(jupyterLabApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/JupyterLabApi.test.js
+++ b/src/services/__tests__/JupyterLabApi.test.js
@@ -1,0 +1,15 @@
+import jupyterLabApi from '../JupyterLabApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('JupyterLabApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(jupyterLabApi.axiosInstance.interceptors.response.handlers).toEqual([
+      interceptor,
+    ]);
+  });
+});

--- a/src/services/__tests__/MonitoringsApi.test.js
+++ b/src/services/__tests__/MonitoringsApi.test.js
@@ -1,7 +1,14 @@
-import monitoringsApi from '../MonitoringsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import monitoringsApi from 'services/MonitoringsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('MonitoringsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(monitoringsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/MonitoringsApi.test.js
+++ b/src/services/__tests__/MonitoringsApi.test.js
@@ -1,0 +1,15 @@
+import monitoringsApi from '../MonitoringsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('MonitoringsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(monitoringsApi.axiosInstance.interceptors.response.handlers).toEqual(
+      [interceptor]
+    );
+  });
+});

--- a/src/services/__tests__/MonitoringsApi.test.js
+++ b/src/services/__tests__/MonitoringsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('MonitoringsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(monitoringsApi.axiosInstance.interceptors.response.handlers).toEqual(

--- a/src/services/__tests__/OperatorsApi.test.js
+++ b/src/services/__tests__/OperatorsApi.test.js
@@ -1,0 +1,15 @@
+import operatorsApi from '../OperatorsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('OperatorsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(operatorsApi.axiosInstance.interceptors.response.handlers).toEqual([
+      interceptor,
+    ]);
+  });
+});

--- a/src/services/__tests__/OperatorsApi.test.js
+++ b/src/services/__tests__/OperatorsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('OperatorsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(operatorsApi.axiosInstance.interceptors.response.handlers).toEqual([

--- a/src/services/__tests__/OperatorsApi.test.js
+++ b/src/services/__tests__/OperatorsApi.test.js
@@ -1,7 +1,14 @@
-import operatorsApi from '../OperatorsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import operatorsApi from 'services/OperatorsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('OperatorsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(operatorsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/ProjectsApi.test.js
+++ b/src/services/__tests__/ProjectsApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('ProjectsApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(projectsApi.axiosInstance.interceptors.response.handlers).toEqual([

--- a/src/services/__tests__/ProjectsApi.test.js
+++ b/src/services/__tests__/ProjectsApi.test.js
@@ -1,7 +1,14 @@
-import projectsApi from '../ProjectsApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import projectsApi from 'services/ProjectsApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('ProjectsApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(projectsApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/ProjectsApi.test.js
+++ b/src/services/__tests__/ProjectsApi.test.js
@@ -1,0 +1,15 @@
+import projectsApi from '../ProjectsApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('ProjectsApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(projectsApi.axiosInstance.interceptors.response.handlers).toEqual([
+      interceptor,
+    ]);
+  });
+});

--- a/src/services/__tests__/TasksApi.test.js
+++ b/src/services/__tests__/TasksApi.test.js
@@ -1,0 +1,15 @@
+import tasksApi from '../TasksApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('TasksApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(tasksApi.axiosInstance.interceptors.response.handlers).toEqual([
+      interceptor,
+    ]);
+  });
+});

--- a/src/services/__tests__/TasksApi.test.js
+++ b/src/services/__tests__/TasksApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('TasksApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(tasksApi.axiosInstance.interceptors.response.handlers).toEqual([

--- a/src/services/__tests__/TasksApi.test.js
+++ b/src/services/__tests__/TasksApi.test.js
@@ -1,7 +1,14 @@
-import tasksApi from '../TasksApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import tasksApi from 'services/TasksApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('TasksApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(tasksApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/__tests__/TemplatesApi.test.js
+++ b/src/services/__tests__/TemplatesApi.test.js
@@ -1,0 +1,15 @@
+import templatesApi from '../TemplatesApi';
+import { AuthExpiredInterceptor } from '../interceptors';
+
+describe('TemplatesApi', () => {
+  it('should have the AuthExpired interceptor attached to the instance', () => {
+    const interceptor = {
+      fulfilled: undefined,
+      rejected: AuthExpiredInterceptor.response.onRejected,
+    };
+
+    expect(templatesApi.axiosInstance.interceptors.response.handlers).toEqual([
+      interceptor,
+    ]);
+  });
+});

--- a/src/services/__tests__/TemplatesApi.test.js
+++ b/src/services/__tests__/TemplatesApi.test.js
@@ -4,8 +4,8 @@ import { AuthExpiredInterceptor } from '../interceptors';
 describe('TemplatesApi', () => {
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
-      fulfilled: undefined,
-      rejected: AuthExpiredInterceptor.response.onRejected,
+      fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+      rejected: AuthExpiredInterceptor.Response.onRejected,
     };
 
     expect(templatesApi.axiosInstance.interceptors.response.handlers).toEqual([

--- a/src/services/__tests__/TemplatesApi.test.js
+++ b/src/services/__tests__/TemplatesApi.test.js
@@ -1,7 +1,14 @@
-import templatesApi from '../TemplatesApi';
-import { AuthExpiredInterceptor } from '../interceptors';
+import templatesApi from 'services/TemplatesApi';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+import { AXIOS_INSTANCE_FACTORY_IDENTIFIER } from 'services/factories';
 
 describe('TemplatesApi', () => {
+  it('should have the axios factory unique identifier', () => {
+    expect(templatesApi.axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
   it('should have the AuthExpired interceptor attached to the instance', () => {
     const interceptor = {
       fulfilled: AuthExpiredInterceptor.Response.onFulfilled,

--- a/src/services/factories/AxiosInstance.factory.js
+++ b/src/services/factories/AxiosInstance.factory.js
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios from 'axios';
 
 import { AuthExpiredInterceptor } from 'services/interceptors';
 
@@ -9,7 +9,7 @@ export const AXIOS_INSTANCE_FACTORY_IDENTIFIER = 'CreatedWithAxiosFactory';
  *
  * @param {object} configs Axios instance configs
  * @param {string} configs.baseURL Axios instance baseURL
- * @returns {AxiosInstance} A new axios instance
+ * @returns {axios} A new axios instance
  */
 export const createAxiosInstance = ({ baseURL }) => {
   const axiosInstance = axios.create({

--- a/src/services/factories/AxiosInstance.factory.js
+++ b/src/services/factories/AxiosInstance.factory.js
@@ -1,0 +1,28 @@
+import axios, { AxiosInstance } from 'axios';
+
+import { AuthExpiredInterceptor } from 'services/interceptors';
+
+export const AXIOS_INSTANCE_FACTORY_IDENTIFIER = 'CreatedWithAxiosFactory';
+
+/**
+ * Creates a new axios instance with default configs.
+ *
+ * @param {object} configs Axios instance configs
+ * @param {string} configs.baseURL Axios instance baseURL
+ * @returns {AxiosInstance} A new axios instance
+ */
+export const createAxiosInstance = ({ baseURL }) => {
+  const axiosInstance = axios.create({
+    baseURL,
+  });
+
+  axiosInstance.interceptors.response.use(
+    AuthExpiredInterceptor.Response.onFulfilled,
+    AuthExpiredInterceptor.Response.onRejected
+  );
+
+  // Custom parameter to identify the instances created with this factory
+  axiosInstance.factoryIdentifier = AXIOS_INSTANCE_FACTORY_IDENTIFIER;
+
+  return axiosInstance;
+};

--- a/src/services/factories/AxiosInstance.factory.test.js
+++ b/src/services/factories/AxiosInstance.factory.test.js
@@ -1,0 +1,30 @@
+import {
+  createAxiosInstance,
+  AXIOS_INSTANCE_FACTORY_IDENTIFIER,
+} from 'services/factories';
+import { AuthExpiredInterceptor } from 'services/interceptors';
+
+describe('AxiosInstance factory', () => {
+  it('should set the default baseURL', () => {
+    const customBaseURL = 'http://localhost:8080';
+    const axiosInstance = createAxiosInstance({ baseURL: customBaseURL });
+    expect(axiosInstance.defaults.baseURL).toBe(customBaseURL);
+  });
+
+  it('should have the axios factory unique identifier', () => {
+    const axiosInstance = createAxiosInstance({ baseURL: '' });
+    expect(axiosInstance.factoryIdentifier).toBe(
+      AXIOS_INSTANCE_FACTORY_IDENTIFIER
+    );
+  });
+
+  it('should contains the auth expired interceptor attached', () => {
+    const axiosInstance = createAxiosInstance({ baseURL: '' });
+    expect(axiosInstance.interceptors.response.handlers).toEqual([
+      {
+        fulfilled: AuthExpiredInterceptor.Response.onFulfilled,
+        rejected: AuthExpiredInterceptor.Response.onRejected,
+      },
+    ]);
+  });
+});

--- a/src/services/factories/index.js
+++ b/src/services/factories/index.js
@@ -1,0 +1,4 @@
+export {
+  createAxiosInstance,
+  AXIOS_INSTANCE_FACTORY_IDENTIFIER,
+} from './AxiosInstance.factory';

--- a/src/services/interceptors/AuthExpired.interceptor.js
+++ b/src/services/interceptors/AuthExpired.interceptor.js
@@ -6,9 +6,8 @@ export const Response = {
     const responseURL = response?.request?.responseURL || '';
     const isResponseURLTheDexAuth = responseURL.includes('/dex/auth');
 
-    if (isContentTypeHTML || isResponseURLTheDexAuth) {
-      const newLocation = isResponseURLTheDexAuth ? responseURL : '/';
-      window.location.assign(newLocation);
+    if (isContentTypeHTML && isResponseURLTheDexAuth) {
+      window.location.assign('/');
       return;
     }
 

--- a/src/services/interceptors/AuthExpired.interceptor.js
+++ b/src/services/interceptors/AuthExpired.interceptor.js
@@ -1,5 +1,11 @@
-export const response = {
+export const Response = {
+  onFulfilled(response) {
+    console.log(response);
+    return response;
+  },
+
   onRejected(error) {
+    console.log(error, error?.response);
     const newLocation = error?.response?.data?.location;
 
     if (newLocation) {

--- a/src/services/interceptors/AuthExpired.interceptor.js
+++ b/src/services/interceptors/AuthExpired.interceptor.js
@@ -1,0 +1,13 @@
+export const response = {
+  onRejected(error) {
+    // The HyperText Transfer Protocol (HTTP) 302 Found redirect status response code indicates that the resource requested has been temporarily moved to the URL given by the Location header. Learn More At https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
+    if (error?.response?.status === 302) {
+      // Redirect to the base route. This will show the login page to the user
+      // window.location.assign saves the new route in the browser history
+      window.location.assign('/');
+      return;
+    }
+
+    return Promise.reject(error);
+  },
+};

--- a/src/services/interceptors/AuthExpired.interceptor.js
+++ b/src/services/interceptors/AuthExpired.interceptor.js
@@ -1,16 +1,24 @@
 export const Response = {
   onFulfilled(response) {
-    console.log(response);
+    const contentType = response?.headers?.['content-type'] || '';
+    const isContentTypeHTML = contentType.includes('text/html');
+
+    const responseURL = response?.request?.responseURL || '';
+    const isResponseURLTheDexAuth = responseURL.includes('/dex/auth');
+
+    if (isContentTypeHTML || isResponseURLTheDexAuth) {
+      const newLocation = isResponseURLTheDexAuth ? responseURL : '/';
+      window.location.assign(newLocation);
+      return;
+    }
+
     return response;
   },
 
   onRejected(error) {
-    console.log(error, error?.response);
     const newLocation = error?.response?.data?.location;
 
     if (newLocation) {
-      // Redirect to the base route. This will show the login page to the user
-      // window.location.assign saves the new route in the browser history
       window.location.assign(newLocation);
       return;
     }

--- a/src/services/interceptors/AuthExpired.interceptor.js
+++ b/src/services/interceptors/AuthExpired.interceptor.js
@@ -8,7 +8,7 @@ export const Response = {
 
     if (isContentTypeHTML && isResponseURLTheDexAuth) {
       window.location.assign('/');
-      return;
+      return Promise.reject(new Error('Redirecionando para o login...'));
     }
 
     return response;

--- a/src/services/interceptors/AuthExpired.interceptor.js
+++ b/src/services/interceptors/AuthExpired.interceptor.js
@@ -1,10 +1,11 @@
 export const response = {
   onRejected(error) {
-    // The HyperText Transfer Protocol (HTTP) 302 Found redirect status response code indicates that the resource requested has been temporarily moved to the URL given by the Location header. Learn More At https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
-    if (error?.response?.status === 302) {
+    const newLocation = error?.response?.data?.location;
+
+    if (newLocation) {
       // Redirect to the base route. This will show the login page to the user
       // window.location.assign saves the new route in the browser history
-      window.location.assign('/');
+      window.location.assign(newLocation);
       return;
     }
 

--- a/src/services/interceptors/AuthExpired.interceptor.test.js
+++ b/src/services/interceptors/AuthExpired.interceptor.test.js
@@ -12,15 +12,15 @@ describe('AuthExpired interceptor', () => {
     window.location = location;
   });
 
-  it('should change window.location when response status is 302', () => {
+  it('should change window.location when the error location exists', () => {
     const error = new Error('The request failed with error 302');
-    error.response = { status: 302 };
+    error.response = { status: 302, data: { location: '/dex/auth' } };
     const returnData = AuthExpiredInterceptor.response.onRejected(error);
-    expect(window.location.assign).toBeCalledWith('/');
+    expect(window.location.assign).toBeCalledWith(error.response.data.location);
     expect(returnData).toBe(undefined);
   });
 
-  it('should return rejected promise if response status is not 302', async () => {
+  it('should return rejected promise if error location is not defined', async () => {
     const error = new Error('The request failed with error 404');
     error.response = { status: 404 };
     const rejectedPromise = AuthExpiredInterceptor.response.onRejected(error);
@@ -28,19 +28,24 @@ describe('AuthExpired interceptor', () => {
     await expect(rejectedPromise).rejects.toEqual(error);
   });
 
-  it('should return rejected promise if the expression "error?.response?.status" returns undefined', async () => {
+  it('should return rejected promise if "error?.response?.data?.location" is undefined', async () => {
     const error1 = undefined;
     const rejectedPromise1 = AuthExpiredInterceptor.response.onRejected(error1);
     await expect(rejectedPromise1).rejects.toEqual(error1);
 
-    const error2 = new Error('An error without response');
+    const error2 = new Error('Without response');
     const rejectedPromise2 = AuthExpiredInterceptor.response.onRejected(error2);
     await expect(rejectedPromise2).rejects.toEqual(error2);
 
-    const error3 = new Error('An error with response but without status');
+    const error3 = new Error('With response but without data');
     error3.response = {};
     const rejectedPromise3 = AuthExpiredInterceptor.response.onRejected(error3);
     await expect(rejectedPromise3).rejects.toEqual(error3);
+
+    const error4 = new Error('With response and data but without location');
+    error4.response = { data: {} };
+    const rejectedPromise4 = AuthExpiredInterceptor.response.onRejected(error4);
+    await expect(rejectedPromise4).rejects.toEqual(error4);
 
     expect(window.location.assign).not.toBeCalled();
   });

--- a/src/services/interceptors/AuthExpired.interceptor.test.js
+++ b/src/services/interceptors/AuthExpired.interceptor.test.js
@@ -12,10 +12,16 @@ describe('AuthExpired interceptor', () => {
     window.location = location;
   });
 
+  it('should return the response object without modifications', () => {
+    const response = { config: {}, data: [] };
+    const newResponse = AuthExpiredInterceptor.Response.onFulfilled(response);
+    expect(newResponse).toBe(response);
+  });
+
   it('should change window.location when the error location exists', () => {
     const error = new Error('The request failed with error 302');
     error.response = { status: 302, data: { location: '/dex/auth' } };
-    const returnData = AuthExpiredInterceptor.response.onRejected(error);
+    const returnData = AuthExpiredInterceptor.Response.onRejected(error);
     expect(window.location.assign).toBeCalledWith(error.response.data.location);
     expect(returnData).toBe(undefined);
   });
@@ -23,28 +29,28 @@ describe('AuthExpired interceptor', () => {
   it('should return rejected promise if error location is not defined', async () => {
     const error = new Error('The request failed with error 404');
     error.response = { status: 404 };
-    const rejectedPromise = AuthExpiredInterceptor.response.onRejected(error);
+    const rejectedPromise = AuthExpiredInterceptor.Response.onRejected(error);
     expect(window.location.assign).not.toBeCalled();
     await expect(rejectedPromise).rejects.toEqual(error);
   });
 
   it('should return rejected promise if "error?.response?.data?.location" is undefined', async () => {
     const error1 = undefined;
-    const rejectedPromise1 = AuthExpiredInterceptor.response.onRejected(error1);
+    const rejectedPromise1 = AuthExpiredInterceptor.Response.onRejected(error1);
     await expect(rejectedPromise1).rejects.toEqual(error1);
 
     const error2 = new Error('Without response');
-    const rejectedPromise2 = AuthExpiredInterceptor.response.onRejected(error2);
+    const rejectedPromise2 = AuthExpiredInterceptor.Response.onRejected(error2);
     await expect(rejectedPromise2).rejects.toEqual(error2);
 
     const error3 = new Error('With response but without data');
     error3.response = {};
-    const rejectedPromise3 = AuthExpiredInterceptor.response.onRejected(error3);
+    const rejectedPromise3 = AuthExpiredInterceptor.Response.onRejected(error3);
     await expect(rejectedPromise3).rejects.toEqual(error3);
 
     const error4 = new Error('With response and data but without location');
     error4.response = { data: {} };
-    const rejectedPromise4 = AuthExpiredInterceptor.response.onRejected(error4);
+    const rejectedPromise4 = AuthExpiredInterceptor.Response.onRejected(error4);
     await expect(rejectedPromise4).rejects.toEqual(error4);
 
     expect(window.location.assign).not.toBeCalled();

--- a/src/services/interceptors/AuthExpired.interceptor.test.js
+++ b/src/services/interceptors/AuthExpired.interceptor.test.js
@@ -19,12 +19,13 @@ describe('AuthExpired interceptor', () => {
     expect(window.location.assign).not.toBeCalled();
   });
 
-  it('should change window.location when response header content-type is text/html and responseURL contains /dex/auth/', () => {
+  it('should change window.location when response header content-type is text/html and responseURL contains /dex/auth/', async () => {
     const response = {
       headers: { 'content-type': 'text/html' },
       request: { responseURL: 'http://.../dex/auth/local' },
     };
-    AuthExpiredInterceptor.Response.onFulfilled(response);
+    const returnedData = AuthExpiredInterceptor.Response.onFulfilled(response);
+    await expect(returnedData).rejects.toBeInstanceOf(Error);
     expect(window.location.assign).toBeCalledWith('/');
   });
 

--- a/src/services/interceptors/AuthExpired.interceptor.test.js
+++ b/src/services/interceptors/AuthExpired.interceptor.test.js
@@ -19,16 +19,13 @@ describe('AuthExpired interceptor', () => {
     expect(window.location.assign).not.toBeCalled();
   });
 
-  it('should change window.location when response header content-type is text/html', () => {
-    const response = { headers: { 'content-type': 'text/html' } };
+  it('should change window.location when response header content-type is text/html and responseURL contains /dex/auth/', () => {
+    const response = {
+      headers: { 'content-type': 'text/html' },
+      request: { responseURL: 'http://.../dex/auth/local' },
+    };
     AuthExpiredInterceptor.Response.onFulfilled(response);
     expect(window.location.assign).toBeCalledWith('/');
-  });
-
-  it('should change window.location when the response contains a responseURL attr that includes /dex/auth', () => {
-    const response = { request: { responseURL: 'http://.../dex/auth/local' } };
-    AuthExpiredInterceptor.Response.onFulfilled(response);
-    expect(window.location.assign).toBeCalledWith(response.request.responseURL);
   });
 
   it('should change window.location when the error location exists', () => {

--- a/src/services/interceptors/AuthExpired.interceptor.test.js
+++ b/src/services/interceptors/AuthExpired.interceptor.test.js
@@ -1,0 +1,47 @@
+import * as AuthExpiredInterceptor from './AuthExpired.interceptor';
+
+describe('AuthExpired interceptor', () => {
+  const { location } = window;
+
+  beforeAll(() => {
+    delete window.location;
+    window.location = { assign: jest.fn() };
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  it('should change window.location when response status is 302', () => {
+    const error = new Error('The request failed with error 302');
+    error.response = { status: 302 };
+    const returnData = AuthExpiredInterceptor.response.onRejected(error);
+    expect(window.location.assign).toBeCalledWith('/');
+    expect(returnData).toBe(undefined);
+  });
+
+  it('should return rejected promise if response status is not 302', async () => {
+    const error = new Error('The request failed with error 404');
+    error.response = { status: 404 };
+    const rejectedPromise = AuthExpiredInterceptor.response.onRejected(error);
+    expect(window.location.assign).not.toBeCalled();
+    await expect(rejectedPromise).rejects.toEqual(error);
+  });
+
+  it('should return rejected promise if the expression "error?.response?.status" returns undefined', async () => {
+    const error1 = undefined;
+    const rejectedPromise1 = AuthExpiredInterceptor.response.onRejected(error1);
+    await expect(rejectedPromise1).rejects.toEqual(error1);
+
+    const error2 = new Error('An error without response');
+    const rejectedPromise2 = AuthExpiredInterceptor.response.onRejected(error2);
+    await expect(rejectedPromise2).rejects.toEqual(error2);
+
+    const error3 = new Error('An error with response but without status');
+    error3.response = {};
+    const rejectedPromise3 = AuthExpiredInterceptor.response.onRejected(error3);
+    await expect(rejectedPromise3).rejects.toEqual(error3);
+
+    expect(window.location.assign).not.toBeCalled();
+  });
+});

--- a/src/services/interceptors/AuthExpired.interceptor.test.js
+++ b/src/services/interceptors/AuthExpired.interceptor.test.js
@@ -16,6 +16,19 @@ describe('AuthExpired interceptor', () => {
     const response = { config: {}, data: [] };
     const newResponse = AuthExpiredInterceptor.Response.onFulfilled(response);
     expect(newResponse).toBe(response);
+    expect(window.location.assign).not.toBeCalled();
+  });
+
+  it('should change window.location when response header content-type is text/html', () => {
+    const response = { headers: { 'content-type': 'text/html' } };
+    AuthExpiredInterceptor.Response.onFulfilled(response);
+    expect(window.location.assign).toBeCalledWith('/');
+  });
+
+  it('should change window.location when the response contains a responseURL attr that includes /dex/auth', () => {
+    const response = { request: { responseURL: 'http://.../dex/auth/local' } };
+    AuthExpiredInterceptor.Response.onFulfilled(response);
+    expect(window.location.assign).toBeCalledWith(response.request.responseURL);
   });
 
   it('should change window.location when the error location exists', () => {

--- a/src/services/interceptors/index.js
+++ b/src/services/interceptors/index.js
@@ -1,1 +1,3 @@
-export * as AuthExpiredInterceptor from './AuthExpired.interceptor';
+import * as AuthExpiredInterceptor from './AuthExpired.interceptor';
+
+export { AuthExpiredInterceptor };

--- a/src/services/interceptors/index.js
+++ b/src/services/interceptors/index.js
@@ -1,0 +1,1 @@
+export * as AuthExpiredInterceptor from './AuthExpired.interceptor';


### PR DESCRIPTION
- Create `AuthExpired interceptor` inside the `services` folder
- Attach `AuthExpired interceptor` in **all API instances**
- Make all files inside the `services` folder return the axios instance
- Test if **all axios instances** have the `AuthExpired interceptor`
- Create factory to generate a new axios instance with the `AuthExpired interceptor` attached. This factory adds a identifier to the instance, so it's possible to check later if a instance was created with the factory. 

P.S. Attach the interceptor to the axios directly is a bad practice because in the future we may want to create an instance axios that does not redirect to the login if the response status be 302.