### PR TITLE
Fix/enable copy url

### DIFF
--- a/src/components/ExternalDatasetDrawer/ExternalDatasetDrawer.component.jsx
+++ b/src/components/ExternalDatasetDrawer/ExternalDatasetDrawer.component.jsx
@@ -20,8 +20,6 @@ const ExternalDatasetDrawer = (props) => {
 
   const [datasetType, setDatasetType] = useState('L');
 
-  const disabledButton = !urlText;
-
   const handleChange = (value) => {
     setDatasetType(value);
   };
@@ -54,7 +52,6 @@ const ExternalDatasetDrawer = (props) => {
               type='secondary'
               icon={<CopyOutlined />}
               shape='round'
-              disabled={disabledButton}
             >
               Copiar URL
             </Button>

--- a/src/components/Modals/ExternalDatasetHelperModal/ExternalDatasetHelperModal.component.jsx
+++ b/src/components/Modals/ExternalDatasetHelperModal/ExternalDatasetHelperModal.component.jsx
@@ -14,8 +14,6 @@ const ExternalDatasetHelperModal = ({
   disabled,
   exampleBody,
 }) => {
-  const disabledButton = !url;
-
   return (
     <Modal
       title={<strong>Como usar uma aplicação como fonte de dados</strong>}
@@ -44,7 +42,6 @@ const ExternalDatasetHelperModal = ({
                 type='primary-inverse'
                 icon={<CopyOutlined />}
                 shape='round'
-                disabled={disabledButton}
               >
                 Copiar URL
               </Button>
@@ -92,8 +89,10 @@ ExternalDatasetHelperModal.defaultProps = {
     "data": {
           "ndarray": [
               [...]
-          ]
-    }
+          ],
+          "names": [...]
+    },
+    "meta": {}
   }`,
   disabled: true,
 };

--- a/src/components/Modals/ExternalDatasetHelperModal/ExternalDatasetHelperModal.md
+++ b/src/components/Modals/ExternalDatasetHelperModal/ExternalDatasetHelperModal.md
@@ -26,14 +26,7 @@ import { Input } from 'antd';
 
 const [visible, setVisible] = React.useState(false);
 const [exampleBody, setExampleBody] = React.useState(`{
-  	"meta":{
-  		"puid": "pqvaab0ej28n89sr4ffjni1ie7",
-  		"tags":{},
-  		"routing":{},
-  		"requestPath":{
-  			"e65e85-a056-40b7-9e4b-4db49ee3b915": "platiagro/platiagro-deployment-image:0.1.0"
-  		},
-  	}
+  	"meta":{}
   }`);
 
 const handleClose = () => {

--- a/src/containers/PropertiesResizableContainer/PropertiesResizableContainer.jsx
+++ b/src/containers/PropertiesResizableContainer/PropertiesResizableContainer.jsx
@@ -19,7 +19,7 @@ export const deploymentsUrlSelector =
   (currentDeploymentId) =>
   ({ deploymentsReducer }) => {
     return deploymentsReducer.find(({ uuid }) => uuid === currentDeploymentId)
-      ?.url;
+      ?.url || `${window.location.origin.toString()}/seldon/anonymous/${currentDeploymentId}/api/v1.0/predictions`;
   };
 
 const PropertiesResizableContainer = () => {

--- a/src/containers/UsingDeploymentsModalContainer/UsingDeploymentsModalContainer.jsx
+++ b/src/containers/UsingDeploymentsModalContainer/UsingDeploymentsModalContainer.jsx
@@ -17,6 +17,7 @@ const request = JSON.stringify(
       names: ['atributo1', 'atributo2'],
       ndarray: [[0, 10]],
     },
+    meta: {}
   },
   null,
   2
@@ -24,15 +25,7 @@ const request = JSON.stringify(
 
 const response = JSON.stringify(
   {
-    meta: {
-      puid: 'pqvaab0ej28n89sr4ffjni1ie7',
-      tags: {},
-      routing: {},
-      requestPath: {
-        'e6065e85-a056-40b7-9e4b-4db49ee3b915':
-          'platiagro/platiagro-deployment-image:0.3.0',
-      },
-    },
+    meta: {},
     data: {
       names: ['atributo1', 'atributo2', 'proba_classe1', 'proba_classe2'],
       ndarray: [[0, 10, 0.8902377788100774, 0.10971507514730343]],


### PR DESCRIPTION
Makes 'copy URL' button always enabled 
Button should be enabled before deployment in order to enable tests.
 
Removes confusing examples from request/response body

Sets a deployment URL when backend returned null 
Allows copying a URL in 'External Dataset' panel.