### PR TITLE
Fix - Add Clear Button To Properties Panel Selects

### DIFF
--- a/src/components/InputBlocks/SelectInputBlock/SelectInputBlock.component.jsx
+++ b/src/components/InputBlocks/SelectInputBlock/SelectInputBlock.component.jsx
@@ -1,9 +1,11 @@
 import React, { useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip, Select, Skeleton } from 'antd';
-import { ExclamationCircleFilled } from '@ant-design/icons';
+import { Tooltip, Select, Skeleton, Popconfirm } from 'antd';
+import { ExclamationCircleFilled, DeleteOutlined } from '@ant-design/icons';
 
 import { PropertyBlock } from 'components';
+
+import './SelectInputBlock.style.less';
 
 const SelectInputBlock = ({
   handleChange,
@@ -42,8 +44,18 @@ const SelectInputBlock = ({
     handleChange(values);
   };
 
+  const handleClearValues = () => {
+    selectRef.current.blur();
+    handleChangeValues(null);
+  };
+
+  const canShowClearButton = () => {
+    if (isMultiple) return value?.length > 0;
+    return !!value;
+  };
+
   return (
-    <PropertyBlock tip={tip} title={title}>
+    <PropertyBlock className='select-input-block' title={title} tip={tip}>
       {isLoading ? (
         <Skeleton
           active
@@ -52,7 +64,7 @@ const SelectInputBlock = ({
           paragraph={{ rows: 1, width: 110 }}
         />
       ) : (
-        <>
+        <div className='select-input-block-content'>
           <Select
             ref={selectRef}
             value={value}
@@ -61,33 +73,41 @@ const SelectInputBlock = ({
             placeholder={placeholder}
             onChange={handleChangeValues}
             disabled={isLoading || isDisabled}
-            style={{
-              width: modifiedSinceLastExecution ? '90%' : '100%',
-            }}
+            className='select-input-block-select'
           >
-            {options &&
-              options.map((option) => {
-                const { uuid, name: optionName } = option;
+            {options?.map((option) => {
+              const { uuid, name: optionName } = option;
 
-                return (
-                  <Select.Option key={uuid || option} value={uuid || option}>
-                    {optionName || option}
-                  </Select.Option>
-                );
-              })}
+              return (
+                <Select.Option key={uuid || option} value={uuid || option}>
+                  {optionName || option}
+                </Select.Option>
+              );
+            })}
           </Select>
+
+          {canShowClearButton() && (
+            <Popconfirm
+              okType='danger'
+              okText='Limpar'
+              cancelText='Cancelar'
+              placement='topLeft'
+              onConfirm={handleClearValues}
+              title='Deseja limpar selecionado(s)?'
+            >
+              <DeleteOutlined className='select-input-block-clear' />
+            </Popconfirm>
+          )}
 
           {modifiedSinceLastExecution && (
             <Tooltip
               placement='bottomRight'
               title='Valor modificado desde a última execução.'
             >
-              <ExclamationCircleFilled
-                style={{ color: '#FAAD14', marginLeft: 5 }}
-              />
+              <ExclamationCircleFilled className='select-input-block-modified' />
             </Tooltip>
           )}
-        </>
+        </div>
       )}
     </PropertyBlock>
   );

--- a/src/components/InputBlocks/SelectInputBlock/SelectInputBlock.style.less
+++ b/src/components/InputBlocks/SelectInputBlock/SelectInputBlock.style.less
@@ -1,0 +1,24 @@
+.select-input-block {
+  .select-input-block-content {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .select-input-block-select {
+    flex: 1;
+  }
+
+  .select-input-block-clear {
+    padding: 8px 0;
+    margin-left: 8px;
+    color: #cf1322;
+  }
+
+  .select-input-block-modified {
+    padding: 8px 0;
+    margin-left: 8px;
+    color: #faad14;
+  }
+}

--- a/src/components/PropertyBlock/PropertyBlock.component.jsx
+++ b/src/components/PropertyBlock/PropertyBlock.component.jsx
@@ -6,9 +6,9 @@ import { TooltipTip } from 'components';
 
 import './PropertyBlock.component.style.less';
 
-const PropertyBlock = ({ children, status, tip, title }) => {
+const PropertyBlock = ({ className, children, status, title, tip }) => {
   return (
-    <div className='propertyBlock'>
+    <div className={`propertyBlock ${className}`}>
       {title && (
         <div className='propertyBlockHeader'>
           {status === 'Failed' && (
@@ -45,15 +45,17 @@ const PropertyBlock = ({ children, status, tip, title }) => {
 
 PropertyBlock.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   status: PropTypes.string,
-  tip: PropTypes.string,
   title: PropTypes.string,
+  tip: PropTypes.string,
 };
 
 PropertyBlock.defaultProps = {
+  className: '',
   status: undefined,
-  tip: undefined,
   title: undefined,
+  tip: undefined,
 };
 
 export default PropertyBlock;


### PR DESCRIPTION
- Add clear button to all selects inside the properties panel
- When the clear button is clicked, a confirmation popup is shown and the user must confirm if he really wants to clear the value(s)