### PR TITLE
Bug Fix - Operators In Negative Coordinate

### DIFF
--- a/src/components/DeploymentFlow/DeploymentFlow.component.jsx
+++ b/src/components/DeploymentFlow/DeploymentFlow.component.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import lodash from 'lodash';
 import PropTypes from 'prop-types';
 import ReactFlow, { Background, Handle } from 'react-flow-renderer';
@@ -25,11 +25,16 @@ const DeploymentFlow = ({
   handleToggleLogsPanel,
   handleDeselectOperator,
 }) => {
+  const [flowInstance, setFlowInstance] = useState(null);
+
+  const handleFitReactFlowView = (reactFlowInstance) => {
+    reactFlowInstance.fitView({ includeHiddenNodes: true  });
+    reactFlowInstance.zoomTo(1);
+  }
+
   const handleLoad = (reactFlowInstance) => {
-    setTimeout(() => {
-      reactFlowInstance.fitView();
-      reactFlowInstance.zoomTo(1);
-    }, 0);
+    setFlowInstance(reactFlowInstance)
+    handleFitReactFlowView(reactFlowInstance)
   };
 
   const handleDragStop = (_, task) => {
@@ -115,6 +120,14 @@ const DeploymentFlow = ({
     operators,
     selectedOperatorId,
   ]);
+
+  // This useEffect updates the position of React Flow when all operators are fetched and flowInstance is set.
+  // Without this useEffect, operators located on a negative X or Y will not be shown in the initial render.
+  useEffect(() => {
+    if(operators?.length && flowInstance) {
+      handleFitReactFlowView(flowInstance)
+    }
+  }, [flowInstance, operators?.length])
 
   return loading ? (
     <div className='deployment-flow'>

--- a/src/components/DeploymentFlow/DeploymentFlow.component.jsx
+++ b/src/components/DeploymentFlow/DeploymentFlow.component.jsx
@@ -28,8 +28,10 @@ const DeploymentFlow = ({
   const [flowInstance, setFlowInstance] = useState(null);
 
   const handleFitReactFlowView = (reactFlowInstance) => {
-    reactFlowInstance.fitView({ includeHiddenNodes: true  });
-    reactFlowInstance.zoomTo(1);
+    setTimeout(() => {
+      reactFlowInstance.fitView({ includeHiddenNodes: true  });
+      reactFlowInstance.zoomTo(1);
+    }, 300)
   }
 
   const handleLoad = (reactFlowInstance) => {

--- a/src/components/DeploymentFlow/DeploymentFlow.component.jsx
+++ b/src/components/DeploymentFlow/DeploymentFlow.component.jsx
@@ -150,6 +150,7 @@ const DeploymentFlow = ({
         onPaneClick={handleDeselectOperator}
         onSelectionChange={handleDeselectOperator}
         onPaneContextMenu={(e) => e.preventDefault()}
+        onlyRenderVisibleElements={false}
       >
         <Background
           variant='dots'

--- a/src/components/DeploymentFlow/DeploymentFlow.component.jsx
+++ b/src/components/DeploymentFlow/DeploymentFlow.component.jsx
@@ -126,7 +126,7 @@ const DeploymentFlow = ({
     if(operators?.length && flowInstance) {
       handleFitReactFlowView(flowInstance)
     }
-  }, [flowInstance, operators?.length])
+  }, [flowInstance, operators])
 
   return (
     <div className='deployment-flow'>

--- a/src/components/DeploymentFlow/DeploymentFlow.component.jsx
+++ b/src/components/DeploymentFlow/DeploymentFlow.component.jsx
@@ -131,15 +131,7 @@ const DeploymentFlow = ({
     }
   }, [flowInstance, operators?.length])
 
-  return loading ? (
-    <div className='deployment-flow'>
-      <OperatorsEmptyPlaceholder
-        className='deployment-flow-empty-operators'
-        placeholderWhenLoading='Aguarde...'
-        loading
-      />
-    </div>
-  ) : (
+  return (
     <div className='deployment-flow'>
       <ReactFlow
         deleteKeyCode={46}
@@ -165,6 +157,8 @@ const DeploymentFlow = ({
         {!operators?.length && (
           <OperatorsEmptyPlaceholder
             className='deployment-flow-empty-operators'
+            loading={loading} 
+            placeholderWhenLoading='Aguarde...'
             placeholder='Crie um fluxo de pré-implantação para visualizar aqui'
           />
         )}

--- a/src/components/DeploymentFlow/DeploymentFlow.component.jsx
+++ b/src/components/DeploymentFlow/DeploymentFlow.component.jsx
@@ -28,10 +28,8 @@ const DeploymentFlow = ({
   const [flowInstance, setFlowInstance] = useState(null);
 
   const handleFitReactFlowView = (reactFlowInstance) => {
-    setTimeout(() => {
-      reactFlowInstance.fitView({ includeHiddenNodes: true  });
-      reactFlowInstance.zoomTo(1);
-    }, 300)
+    reactFlowInstance.fitView({ includeHiddenNodes: true  });
+    reactFlowInstance.zoomTo(1);
   }
 
   const handleLoad = (reactFlowInstance) => {
@@ -123,7 +121,6 @@ const DeploymentFlow = ({
     selectedOperatorId,
   ]);
 
-  // This useEffect updates the position of React Flow when all operators are fetched and flowInstance is set.
   // Without this useEffect, operators located on a negative X or Y will not be shown in the initial render.
   useEffect(() => {
     if(operators?.length && flowInstance) {

--- a/src/components/ToolbarConfig/ToolbarConfig.component.jsx
+++ b/src/components/ToolbarConfig/ToolbarConfig.component.jsx
@@ -21,29 +21,22 @@ const ToolbarConfig = ({ handleDeleteClick, operator, deployment }) => {
     <>
       <Button icon={<ZoomInOutlined />} type='text' onClick={zoomIn} />
       <Button icon={<ZoomOutOutlined />} type='text' onClick={zoomOut} />
+      <Button icon={<ExpandOutlined />} type='text' onClick={handleFitView} />
 
       {!deployment && (
-        <>
+        <Popconfirm
+          title='Você tem certeza que deseja excluir esta tarefa?'
+          onConfirm={handleDeleteClick}
+          okText='Sim'
+          cancelText='Não'
+          disabled={!operator?.uuid}
+        >
           <Button
-            icon={<ExpandOutlined />}
+            icon={<DeleteOutlined />}
             type='text'
-            onClick={handleFitView}
-          />
-
-          <Popconfirm
-            title='Você tem certeza que deseja excluir esta tarefa?'
-            onConfirm={handleDeleteClick}
-            okText='Sim'
-            cancelText='Não'
             disabled={!operator?.uuid}
-          >
-            <Button
-              icon={<DeleteOutlined />}
-              type='text'
-              disabled={!operator?.uuid}
-            />
-          </Popconfirm>
-        </>
+          />
+        </Popconfirm>
       )}
     </>
   );

--- a/src/pages/Experiments/Experiment/ExperimentFlow/index.js
+++ b/src/pages/Experiments/Experiment/ExperimentFlow/index.js
@@ -170,6 +170,7 @@ const ExperimentFlow = ({
         onPaneContextMenu={(e) => e.preventDefault()}
         onConnectStart={() => setConnectClass('Connecting')}
         onElementsRemove={handleDeleteOperator}
+        onlyRenderVisibleElements={false}
       >
         <Background
           gap={25}

--- a/src/pages/Experiments/Experiment/ExperimentFlow/index.js
+++ b/src/pages/Experiments/Experiment/ExperimentFlow/index.js
@@ -33,10 +33,8 @@ const ExperimentFlow = ({
   const [flowInstance, setFlowInstance] = useState(null);
 
   const handleFitReactFlowView = (reactFlowInstance) => {
-    setTimeout(() => {
-      reactFlowInstance.fitView({ includeHiddenNodes: true  });
-      reactFlowInstance.zoomTo(1);
-    }, 300)
+    reactFlowInstance.fitView({ includeHiddenNodes: true  });
+    reactFlowInstance.zoomTo(1);
   }
 
   const handleLoad = (reactFlowInstance) => {
@@ -143,7 +141,6 @@ const ExperimentFlow = ({
   const cursorStyle = operatorLoading ? { cursor: 'wait' } : {};
   const emptyOperators = tasks.length === 0;
 
-  // This useEffect updates the position of React Flow when all tasks are fetched and flowInstance is set.
   // Without this useEffect, operators located on a negative X or Y will not be shown in the initial render.
   useEffect(() => {
     if(tasks?.length && flowInstance) {

--- a/src/pages/Experiments/Experiment/ExperimentFlow/index.js
+++ b/src/pages/Experiments/Experiment/ExperimentFlow/index.js
@@ -33,8 +33,10 @@ const ExperimentFlow = ({
   const [flowInstance, setFlowInstance] = useState(null);
 
   const handleFitReactFlowView = (reactFlowInstance) => {
-    reactFlowInstance.fitView({ includeHiddenNodes: true  });
-    reactFlowInstance.zoomTo(1);
+    setTimeout(() => {
+      reactFlowInstance.fitView({ includeHiddenNodes: true  });
+      reactFlowInstance.zoomTo(1);
+    }, 300)
   }
 
   const handleLoad = (reactFlowInstance) => {

--- a/src/pages/Experiments/Experiment/ExperimentFlow/index.js
+++ b/src/pages/Experiments/Experiment/ExperimentFlow/index.js
@@ -1,12 +1,12 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import lodash from 'lodash';
 import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import ReactFlow, { Background } from 'react-flow-renderer';
 
 import TaskBox from 'components/TaskBox';
-import { OperatorsEmptyPlaceholder } from 'components/EmptyPlaceholders';
 import { LogsButton } from 'components/Buttons';
+import { OperatorsEmptyPlaceholder } from 'components/EmptyPlaceholders';
 
 import Vectors, { nodeTypes, edgeTypes } from './CustomNodes';
 
@@ -30,12 +30,16 @@ const ExperimentFlow = ({
   handleRemoveOperator,
 }) => {
   const [connectClass, setConnectClass] = useState('');
+  const [flowInstance, setFlowInstance] = useState(null);
+
+  const handleFitReactFlowView = (reactFlowInstance) => {
+    reactFlowInstance.fitView({ includeHiddenNodes: true  });
+    reactFlowInstance.zoomTo(1);
+  }
 
   const handleLoad = (reactFlowInstance) => {
-    setTimeout(() => {
-      reactFlowInstance.fitView();
-      reactFlowInstance.zoomTo(1);
-    }, 0);
+    setFlowInstance(reactFlowInstance)
+    handleFitReactFlowView(reactFlowInstance)
   };
 
   const handleConnect = (params) => {
@@ -135,8 +139,15 @@ const ExperimentFlow = ({
   });
 
   const cursorStyle = operatorLoading ? { cursor: 'wait' } : {};
-
   const emptyOperators = tasks.length === 0;
+
+  // This useEffect updates the position of React Flow when all tasks are fetched and flowInstance is set.
+  // Without this useEffect, operators located on a negative X or Y will not be shown in the initial render.
+  useEffect(() => {
+    if(tasks?.length && flowInstance) {
+      handleFitReactFlowView(flowInstance)
+    }
+  }, [flowInstance, tasks?.length])
 
   return (
     <div
@@ -159,7 +170,6 @@ const ExperimentFlow = ({
         onPaneContextMenu={(e) => e.preventDefault()}
         onConnectStart={() => setConnectClass('Connecting')}
         onElementsRemove={handleDeleteOperator}
-        onlyRenderVisibleElements
       >
         <Background
           gap={25}


### PR DESCRIPTION
## Bug Description

When an operator is positioned in a negative coordinate (X or Y) and is out of the view box, it disappears completely and the user cannot find it.

## Solution Implemented

Call `fitView({ includeHiddenNodes: true  })` and `zoomTo(1)` when React Flow renders and when all operators are fetched. This way the React Flow focuses the operators wherever they are.