### PR TITLE
Fix - Rename Google Drive Operator

### DIFF
--- a/src/containers/DatasetUploadInputBlockContainer/DatasetUploadInputBlockContainer.jsx
+++ b/src/containers/DatasetUploadInputBlockContainer/DatasetUploadInputBlockContainer.jsx
@@ -43,8 +43,8 @@ const datasetNameSelector = ({ datasetReducer }) => {
   return datasetReducer.name;
 };
 
-const operatorNameSelector = ({ operatorReducer }) => {
-  return operatorReducer.name;
+const operatorTaskNameSelector = ({ operatorReducer }) => {
+  return operatorReducer?.task?.name || '';
 };
 
 const isDisabledSelector = ({ uiReducer }) => {
@@ -64,10 +64,10 @@ const DatasetUploadInputBlockContainer = () => {
   const { projectId, experimentId } = useParams();
   const dispatch = useDispatch();
 
+  const operatorTaskName = useSelector(operatorTaskNameSelector);
   const datasetFileName = useSelector(datasetFileNameSelector);
   const uploadProgress = useSelector(uploadProgressSelector);
   const datasetStatus = useSelector(datasetStatusSelector);
-  const operatorName = useSelector(operatorNameSelector);
   const isUploading = useSelector(isUploadingSelector);
   const datasetName = useSelector(datasetNameSelector);
   const isDisabled = useSelector(isDisabledSelector);
@@ -111,8 +111,9 @@ const DatasetUploadInputBlockContainer = () => {
   ]);
 
   const isGoogleDrive = useMemo(() => {
-    return operatorName === 'Google Drive';
-  }, [operatorName]);
+    const expectedTaskName = 'Google Drive'.toLowerCase();
+    return operatorTaskName.toLowerCase().includes(expectedTaskName);
+  }, [operatorTaskName]);
 
   const experimentIsSucceeded = useMemo(() => {
     return utils.checkExperimentSuccess({ operators });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Renaming the Google Drive dataset operator turns it into a simple file upload dataset.

* **What is the new behavior (if this is a feature change)?**
Now the user can rename the Google Drive dataset operator freely.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as platiagro/web-ui)
No
